### PR TITLE
MCP: Properly handle uninitialized workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ yarn-error.log*
 # Vinxi
 .vinxi
 .output
+
+*.log

--- a/apps/mcp/index.ts
+++ b/apps/mcp/index.ts
@@ -1,31 +1,41 @@
 import { parseArgs } from "@std/cli/parse-args";
 import { join } from "node:path";
 import { RejotMcp } from "./rejot-mcp";
-import { ProjectInitializer } from "./project/project";
+import { WorkspaceResources } from "./workspace/workspace.resources";
 import { ManifestWorkspaceResolver } from "@rejot-dev/contract-tools/manifest";
 import { DbIntrospectionTool } from "./tools/db-introspection/db-introspection.tool";
 import { ManifestInfoTool } from "./tools/manifest/manifest-info.tool";
+import { ManifestInitTool } from "./tools/manifest/manifest-init.tool";
 import { setLogger, FileLogger } from "@rejot-dev/contract/logger";
-
-const log = setLogger(new FileLogger(join(__dirname, "mcp.log")));
-
+import { WorkspaceService } from "./workspace/workspace";
 // Open the log file when starting up
 const args = parseArgs(process.argv.slice(2));
 
 if (!("project" in args)) {
-  log.error("No project provided", args);
+  console.error("No project provided", args);
   process.exit(1);
 }
 
+const log = setLogger(new FileLogger(join(args.project, "mcp.log"), "DEBUG"));
+
+const workspaceService = new WorkspaceService(new ManifestWorkspaceResolver());
+
 const rejotMcp = new RejotMcp(args.project, log, [
-  new ProjectInitializer(new ManifestWorkspaceResolver()),
+  new WorkspaceResources(workspaceService),
   new DbIntrospectionTool(),
   new ManifestInfoTool(),
+  new ManifestInitTool(workspaceService),
 ]);
 
 rejotMcp
   .connect()
   .then(() => {})
   .catch((err) => {
-    log.error("Server error", err);
+    log.error(`Server error: ${err.message}`);
+
+    if (err instanceof Error) {
+      for (const stack of err.stack?.split("\n") ?? []) {
+        log.error(stack);
+      }
+    }
   });

--- a/apps/mcp/interfaces/mcp-server.interface.ts
+++ b/apps/mcp/interfaces/mcp-server.interface.ts
@@ -13,7 +13,6 @@ import type { ZodRawShape, ZodType, ZodOptional } from "zod";
 /**
  * URL variables from a resource template
  */
-export type Variables = Record<string, string>;
 
 // Re-export the types we need from the actual McpServer implementation
 export type ResourceMetadata = ActualResourceMetadata;

--- a/apps/mcp/rejot-mcp-client.ts
+++ b/apps/mcp/rejot-mcp-client.ts
@@ -29,6 +29,7 @@ const result = await client.callTool({
   },
 });
 
+console.log("result");
 console.dir(result, { depth: null });
 
 await client.close();

--- a/apps/mcp/state/mcp-error.ts
+++ b/apps/mcp/state/mcp-error.ts
@@ -1,21 +1,71 @@
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult, ReadResourceResult } from "@modelcontextprotocol/sdk/types.js";
 
 export abstract class ReJotMcpError extends Error {
-  constructor(message: string) {
-    super(message);
+  protected hints: string[] = [];
+
+  constructor(message: string, cause?: Error) {
+    super(message, { cause });
   }
 
-  abstract toContent(): CallToolResult["content"];
-}
+  withHint(hint: string): this {
+    this.hints.push(hint);
+    return this;
+  }
 
-export class SyncManifestNotInitializedError extends ReJotMcpError {
-  toContent(): CallToolResult["content"] {
+  withHints(hints: string[]): this {
+    this.hints.push(...hints);
+    return this;
+  }
+
+  toCallToolContent(): CallToolResult["content"] {
     return [
       {
         isError: true,
         type: "text",
-        text: this.message,
+        text: this.getFormattedText(),
       },
     ];
+  }
+
+  toReadResourceContent(uri: string): ReadResourceResult["contents"] {
+    return [
+      {
+        text: this.getFormattedText(),
+        uri,
+      },
+    ];
+  }
+
+  protected getFormattedText(): string {
+    if (this.hints.length === 0) {
+      return this.message;
+    }
+
+    const hintsText = this.hints.map((hint) => `\n• ${hint}`).join("");
+
+    return `${this.message}\n\nHints:${hintsText}`;
+  }
+}
+
+export class WorkspaceNotInitializedError extends ReJotMcpError {
+  get name(): string {
+    return "WorkspaceNotInitializedError";
+  }
+}
+
+export class CombinedRejotMcpError extends ReJotMcpError {
+  #errors: ReJotMcpError[];
+
+  constructor(errors: ReJotMcpError[]) {
+    super("CombinedRejotMcpError");
+    this.#errors = errors;
+  }
+
+  toCallToolContent(): CallToolResult["content"] {
+    return this.#errors.flatMap((e) => e.toCallToolContent());
+  }
+
+  toReadResourceContent(uri: string): ReadResourceResult["contents"] {
+    return this.#errors.flatMap((e) => e.toReadResourceContent(uri));
   }
 }

--- a/apps/mcp/state/mcp-state.ts
+++ b/apps/mcp/state/mcp-state.ts
@@ -1,19 +1,16 @@
 import type { Workspace } from "@rejot-dev/contract-tools/manifest";
 import type { SyncManifest } from "@rejot-dev/contract/sync-manifest";
-import type { ManifestError } from "@rejot-dev/contract/manifest";
-import { SyncManifestNotInitializedError as WorkspaceNotInitializedError } from "./mcp-error";
+import {
+  WorkspaceNotInitializedError,
+  type ReJotMcpError,
+  CombinedRejotMcpError,
+} from "./mcp-error";
 
 export type McpStateStatus = "uninitialized" | "initializing" | "ready" | "error";
 
-export interface McpStateError {
-  message: string;
-  errors?: ManifestError[];
-}
-
 export class McpState {
   readonly projectDir: string;
-  #status: McpStateStatus = "uninitialized";
-  #error: McpStateError | undefined;
+  #initializationErrors: ReJotMcpError[] = [];
 
   // Core state
   #workspace: Workspace | undefined;
@@ -23,31 +20,34 @@ export class McpState {
     this.projectDir = projectDir;
   }
 
-  get status(): McpStateStatus {
-    return this.#status;
+  get hasWorkspace(): boolean {
+    return !!this.#workspace;
   }
 
   get workspace(): Workspace {
     if (!this.#workspace) {
-      throw new WorkspaceNotInitializedError("McpState / Workspace not initialized");
+      throw new WorkspaceNotInitializedError("McpState / Workspace not initialized").withHint(
+        "A workspace has to be initialized first. By initiating the creation of a manifest.",
+      );
     }
     return this.#workspace;
   }
 
   get syncManifest(): SyncManifest {
     if (!this.#syncManifest) {
-      throw new WorkspaceNotInitializedError("McpState / Sync manifest not initialized");
+      throw new WorkspaceNotInitializedError("McpState / Sync manifest not initialized").withHint(
+        "A sync manifest has to be initialized first. By initiating the creation of a manifest.",
+      );
     }
     return this.#syncManifest;
   }
 
-  get error(): McpStateError | undefined {
-    return this.#error;
+  get initializationErrors(): ReJotMcpError[] {
+    return this.#initializationErrors;
   }
 
   setInitializing(): void {
-    this.#status = "initializing";
-    this.#error = undefined;
+    this.#initializationErrors = [];
   }
 
   setWorkspace(workspace: Workspace): void {
@@ -56,11 +56,19 @@ export class McpState {
 
   setSyncManifest(syncManifest: SyncManifest): void {
     this.#syncManifest = syncManifest;
-    this.#status = "ready";
   }
 
-  setError(error: McpStateError): void {
-    this.#error = error;
-    this.#status = "error";
+  addInitializationError(error: ReJotMcpError): void {
+    this.#initializationErrors.push(error);
+  }
+
+  clearInitializationErrors(): void {
+    this.#initializationErrors = [];
+  }
+
+  assertIsInitialized(): void {
+    if (this.#initializationErrors.length > 0) {
+      throw new CombinedRejotMcpError(this.#initializationErrors);
+    }
   }
 }

--- a/apps/mcp/tools/manifest/manifest-info.tool.ts
+++ b/apps/mcp/tools/manifest/manifest-info.tool.ts
@@ -16,6 +16,7 @@ export class ManifestInfoTool implements IFactory {
       "Get information about the workspace's manifest.",
       {},
       async () => {
+        mcp.state.assertIsInitialized();
         const output = ManifestPrinter.printSyncManifest(mcp.state.syncManifest);
         return {
           content: [{ type: "text", text: output.join("\n") }],

--- a/apps/mcp/tools/manifest/manifest-init.tool.ts
+++ b/apps/mcp/tools/manifest/manifest-init.tool.ts
@@ -1,0 +1,72 @@
+import { z } from "zod";
+import { initManifest } from "@rejot-dev/contract-tools/manifest";
+import type { IRejotMcp, IFactory } from "@/rejot-mcp";
+import type { McpState } from "@/state/mcp-state";
+import type { IWorkspaceService } from "@/workspace/workspace";
+import { dirname } from "node:path";
+
+export class ManifestInitTool implements IFactory {
+  readonly #workspaceService: IWorkspaceService;
+
+  constructor(workspaceService: IWorkspaceService) {
+    this.#workspaceService = workspaceService;
+  }
+
+  async initialize(_state: McpState): Promise<void> {
+    // No state initialization needed
+  }
+
+  async register(mcp: IRejotMcp): Promise<void> {
+    mcp.registerTool(
+      "mcp_rejot_mcp_manifest_init",
+      "Initialize a new manifest file at the specified path",
+      {
+        manifestAbsoluteFilePath: z
+          .string()
+          .describe(
+            "The path to the manifest file to create. Normally the file name is 'rejot-manifest.json'.",
+          ),
+        slug: z.string().describe("The slug for the manifest."),
+      },
+      async ({ manifestAbsoluteFilePath, slug }) => {
+        try {
+          await initManifest(manifestAbsoluteFilePath, slug);
+          const { workspace, syncManifest } = await this.#workspaceService.initWorkspace(
+            dirname(manifestAbsoluteFilePath),
+          );
+          mcp.state.setWorkspace(workspace);
+          mcp.state.setSyncManifest(syncManifest);
+          mcp.state.clearInitializationErrors();
+
+          return {
+            content: [
+              { type: "text", text: `Created new manifest file at ${manifestAbsoluteFilePath}` },
+              // TODO: Explain next steps here maybe.
+            ],
+          };
+        } catch (error) {
+          if (error instanceof Error && "code" in error && error.code === "EEXIST") {
+            return {
+              content: [
+                {
+                  isError: true,
+                  type: "text",
+                  text: `Manifest file already exists at ${manifestAbsoluteFilePath}. Use a different path or remove the existing file.`,
+                },
+              ],
+            };
+          }
+          return {
+            content: [
+              {
+                isError: true,
+                type: "text",
+                text: `Failed to create manifest: ${error instanceof Error ? error.message : String(error)}`,
+              },
+            ],
+          };
+        }
+      },
+    );
+  }
+}

--- a/apps/mcp/workspace/workspace.test.ts
+++ b/apps/mcp/workspace/workspace.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, mock } from "bun:test";
 import { MockRejotMcp } from "../_test/mock-mcp-server";
-import { ProjectInitializer } from "./project";
+import { WorkspaceResources } from "./workspace.resources";
 import type {
   IManifestWorkspaceResolver,
   Workspace,
   ManifestInfo,
 } from "@rejot-dev/contract-tools/manifest";
 import { workspaceToSyncManifest } from "@rejot-dev/contract-tools/manifest/manifest-workspace-resolver";
-
+import { WorkspaceService } from "./workspace";
 // Create a sample manifest
 const createBasicManifest = (slug: string) => ({
   slug,
@@ -80,18 +80,18 @@ const createComplexTestWorkspace = (): Workspace => ({
   ],
 });
 
-describe("ProjectInitializer", () => {
+describe("WorkspaceResources", () => {
   it("should initialize and register workspace resources", async () => {
     // Arrange
     const testWorkspace = createTestWorkspace();
     const mockWorkspaceResolver = createMockWorkspaceResolver(testWorkspace);
-    const projectInitializer = new ProjectInitializer(mockWorkspaceResolver);
+    const workspaceResources = new WorkspaceResources(new WorkspaceService(mockWorkspaceResolver));
 
     const mockMcp = new MockRejotMcp("/test/project/dir");
 
     // Act
-    await projectInitializer.initialize(mockMcp.state);
-    await projectInitializer.register(mockMcp);
+    await workspaceResources.initialize(mockMcp.state);
+    await workspaceResources.register(mockMcp);
 
     // Assert
     // 1. Verify that resolveWorkspace was called with correct parameters
@@ -115,13 +115,13 @@ describe("ProjectInitializer", () => {
     // Arrange
     const testWorkspace = createTestWorkspace();
     const mockWorkspaceResolver = createMockWorkspaceResolver(testWorkspace);
-    const projectInitializer = new ProjectInitializer(mockWorkspaceResolver);
+    const workspaceResources = new WorkspaceResources(new WorkspaceService(mockWorkspaceResolver));
 
     const mockMcp = new MockRejotMcp("/test/project/dir");
 
     // Act
-    await projectInitializer.initialize(mockMcp.state);
-    await projectInitializer.register(mockMcp);
+    await workspaceResources.initialize(mockMcp.state);
+    await workspaceResources.register(mockMcp);
 
     // Get the registered resource template
     const resources = mockMcp.getResources();
@@ -142,13 +142,13 @@ describe("ProjectInitializer", () => {
       children: [],
     };
     const mockWorkspaceResolver = createMockWorkspaceResolver(testWorkspace);
-    const projectInitializer = new ProjectInitializer(mockWorkspaceResolver);
+    const workspaceResources = new WorkspaceResources(new WorkspaceService(mockWorkspaceResolver));
 
     const mockMcp = new MockRejotMcp("/test/project/dir");
 
     // Act
-    await projectInitializer.initialize(mockMcp.state);
-    await projectInitializer.register(mockMcp);
+    await workspaceResources.initialize(mockMcp.state);
+    await workspaceResources.register(mockMcp);
 
     // Get the registered resource template
     const resources = mockMcp.getResources();
@@ -162,13 +162,13 @@ describe("ProjectInitializer", () => {
     // Arrange
     const testWorkspace = createComplexTestWorkspace();
     const mockWorkspaceResolver = createMockWorkspaceResolver(testWorkspace);
-    const projectInitializer = new ProjectInitializer(mockWorkspaceResolver);
+    const workspaceResources = new WorkspaceResources(new WorkspaceService(mockWorkspaceResolver));
 
     const mockMcp = new MockRejotMcp("/complex/project/dir");
 
     // Act
-    await projectInitializer.initialize(mockMcp.state);
-    await projectInitializer.register(mockMcp);
+    await workspaceResources.initialize(mockMcp.state);
+    await workspaceResources.register(mockMcp);
 
     // Assert
     const resources = mockMcp.getResources();

--- a/apps/mcp/workspace/workspace.ts
+++ b/apps/mcp/workspace/workspace.ts
@@ -1,0 +1,60 @@
+import type { IManifestWorkspaceResolver, Workspace } from "@rejot-dev/contract-tools/manifest";
+import type { SyncManifest } from "@rejot-dev/contract/sync-manifest";
+import { getLogger } from "@rejot-dev/contract/logger";
+import { ReJotMcpError } from "@/state/mcp-error";
+
+const log = getLogger("mcp.workspace");
+
+export interface IWorkspaceService {
+  initWorkspace(projectDir: string): Promise<{ workspace: Workspace; syncManifest: SyncManifest }>;
+}
+
+export class WorkspaceInitializationError extends ReJotMcpError {}
+
+export class WorkspaceService implements IWorkspaceService {
+  readonly #workspaceResolver: IManifestWorkspaceResolver;
+
+  constructor(workspaceResolver: IManifestWorkspaceResolver) {
+    this.#workspaceResolver = workspaceResolver;
+  }
+
+  async initWorkspace(
+    projectDir: string,
+  ): Promise<{ workspace: Workspace; syncManifest: SyncManifest }> {
+    const workspace = await this.#workspaceResolver.resolveWorkspace({
+      startDir: projectDir,
+    });
+
+    if (!workspace) {
+      throw new WorkspaceInitializationError("No workspace found in project directory").withHint(
+        "Create a new manifest if this is a new workspace",
+      );
+    }
+
+    log.info("Workspace resolved", {
+      rootPath: workspace.rootPath,
+      ancestor: workspace.ancestor.path,
+      children: workspace.children.map((c) => c.path),
+    });
+
+    try {
+      const syncManifest = this.#workspaceResolver.workspaceToSyncManifest(workspace);
+
+      return {
+        workspace,
+        syncManifest,
+      };
+    } catch (error) {
+      // Handle sync manifest creation errors
+      if (error instanceof Error) {
+        throw new WorkspaceInitializationError("Failed to create sync manifest").withHint(
+          error.message,
+        );
+      }
+
+      throw new WorkspaceInitializationError(
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+}

--- a/packages/contract-tools/manifest/manifest-workspace-resolver.ts
+++ b/packages/contract-tools/manifest/manifest-workspace-resolver.ts
@@ -33,7 +33,7 @@ export interface ManifestInfo {
 }
 
 export interface IManifestWorkspaceResolver {
-  resolveWorkspace(options?: ResolveWorkspaceOptions): Promise<Workspace>;
+  resolveWorkspace(options?: ResolveWorkspaceOptions): Promise<Workspace | null>;
   getManifestInfo(filePath: string): Promise<ManifestInfo>;
   workspaceToSyncManifest(workspace: Workspace): SyncManifest;
 }
@@ -50,7 +50,7 @@ export class ManifestWorkspaceResolver implements IManifestWorkspaceResolver {
     };
   }
 
-  async resolveWorkspace(options: ResolveWorkspaceOptions = {}): Promise<Workspace> {
+  async resolveWorkspace(options: ResolveWorkspaceOptions = {}): Promise<Workspace | null> {
     const {
       startDir = process.cwd(),
       filename = DEFAULT_MANIFEST_FILENAME,
@@ -60,7 +60,7 @@ export class ManifestWorkspaceResolver implements IManifestWorkspaceResolver {
     // Find the ancestor manifest path
     const manifestPath = await findManifestPath(startDir, filename);
     if (!manifestPath) {
-      throw new Error("Ancestor manifest not found");
+      return null;
     }
 
     const ancestorManifest = await readManifest(manifestPath);


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Improved error handling for uninitialized workspaces in the Model Context Protocol (MCP) server. This change allows the MCP to gracefully handle cases where a workspace hasn't been set up yet, providing clear error messages and initialization options.

- **New Features**
  - Added `ManifestInitTool` to initialize new manifests via a tool call
  - Created dedicated `WorkspaceService` to centralize workspace initialization logic
  - Added helpful error hints to guide users when operations fail
  - Implemented resource registration with proper error handling

- **Refactors**
  - Restructured error handling to provide more context in error messages
  - Moved workspace initialization from `ProjectInitializer` to `WorkspaceService`
  - Enhanced logger to support namespacing and better file logging
  - Improved state management to track initialization errors

- **Bug Fixes**
  - Fixed error handling when workspace isn't initialized
  - Properly formatted error responses in resource and tool handlers
  - Updated workspace resolver to return null instead of throwing when no manifest exists

<!-- End of auto-generated description by mrge. -->

