### PR TITLE
MCP: functionality to add connection

### DIFF
--- a/apps/mcp/index.ts
+++ b/apps/mcp/index.ts
@@ -8,6 +8,8 @@ import { ManifestInfoTool } from "./tools/manifest/manifest-info.tool";
 import { ManifestInitTool } from "./tools/manifest/manifest-init.tool";
 import { setLogger, FileLogger } from "@rejot-dev/contract/logger";
 import { WorkspaceService } from "./workspace/workspace";
+import { ManifestConnectionTool } from "./tools/manifest-connection/manifest-connection.tool";
+
 // Open the log file when starting up
 const args = parseArgs(process.argv.slice(2));
 
@@ -25,6 +27,7 @@ const rejotMcp = new RejotMcp(args.project, log, [
   new DbIntrospectionTool(),
   new ManifestInfoTool(),
   new ManifestInitTool(workspaceService),
+  new ManifestConnectionTool(),
 ]);
 
 rejotMcp
@@ -32,10 +35,5 @@ rejotMcp
   .then(() => {})
   .catch((err) => {
     log.error(`Server error: ${err.message}`);
-
-    if (err instanceof Error) {
-      for (const stack of err.stack?.split("\n") ?? []) {
-        log.error(stack);
-      }
-    }
+    log.logErrorInstance(err);
   });

--- a/apps/mcp/rejot-manifest.json
+++ b/apps/mcp/rejot-manifest.json
@@ -1,0 +1,21 @@
+{
+  "slug": "wilco-postgres",
+  "manifestVersion": 0,
+  "connections": [
+    {
+      "slug": "wilco-postgres",
+      "config": {
+        "connectionType": "postgres",
+        "host": "localhost",
+        "port": 5432,
+        "user": "postgres",
+        "password": "postgres",
+        "database": "postgres"
+      }
+    }
+  ],
+  "dataStores": [],
+  "eventStores": [],
+  "publicSchemas": [],
+  "consumerSchemas": []
+}

--- a/apps/mcp/rejot-mcp-client.ts
+++ b/apps/mcp/rejot-mcp-client.ts
@@ -2,11 +2,10 @@
 
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const projectRoot = resolve(__dirname, "../..");
+// const __dirname = dirname(fileURLToPath(import.meta.url));
+// const projectRoot = resolve(__dirname, "../..");
+const projectRoot = "/private/tmp/thing";
 
 const transport = new StdioClientTransport({
   command: "bun",
@@ -22,10 +21,26 @@ await client.connect(transport);
 
 console.log("connected");
 
+// const result = await client.callTool({
+//   name: "mcp_rejot_db_check_health",
+//   arguments: {
+//     connectionSlug: "data-destination-1",
+//   },
+// });
+
 const result = await client.callTool({
-  name: "mcp_rejot_db_check_health",
+  name: "rejot_manifest_connection_add_postgres",
   arguments: {
-    connectionSlug: "data-destination-1",
+    manifestSlug: "wilco-postgres",
+    newConnectionSlug: "wilco-postgres",
+    postgresConnection: {
+      connectionType: "postgres",
+      host: "localhost",
+      port: 5432,
+      user: "postgres",
+      password: "postgres",
+      database: "postgres",
+    },
   },
 });
 

--- a/apps/mcp/state/mcp-state.ts
+++ b/apps/mcp/state/mcp-state.ts
@@ -5,6 +5,9 @@ import {
   type ReJotMcpError,
   CombinedRejotMcpError,
 } from "./mcp-error";
+import { getLogger } from "@rejot-dev/contract/logger";
+
+const log = getLogger("mcp.state");
 
 export type McpStateStatus = "uninitialized" | "initializing" | "ready" | "error";
 
@@ -68,6 +71,7 @@ export class McpState {
 
   assertIsInitialized(): void {
     if (this.#initializationErrors.length > 0) {
+      log.warn("assertIsInitialized failed");
       throw new CombinedRejotMcpError(this.#initializationErrors);
     }
   }

--- a/apps/mcp/tools/manifest-connection/manifest-connection.tool.ts
+++ b/apps/mcp/tools/manifest-connection/manifest-connection.tool.ts
@@ -1,0 +1,87 @@
+import type { IFactory, IRejotMcp } from "@/rejot-mcp";
+import type { McpState } from "@/state/mcp-state";
+import { PostgresConnectionSchema } from "@rejot-dev/adapter-postgres/schemas";
+import { writeManifest } from "@rejot-dev/contract-tools/manifest";
+import { getManifestBySlug } from "@rejot-dev/contract-tools/manifest/manifest-workspace-resolver";
+import { join } from "node:path";
+import { z } from "zod";
+
+export class ManifestConnectionTool implements IFactory {
+  async initialize(_state: McpState): Promise<void> {
+    //
+  }
+
+  async register(mcp: IRejotMcp): Promise<void> {
+    mcp.registerTool(
+      "rejot_manifest_connection_add_postgres",
+      "Add a postgres connection to the specified manifest.",
+      {
+        manifestSlug: z.string(),
+        newConnectionSlug: z.string(),
+        shouldReplaceIfConnectionExists: z.boolean().optional(),
+        postgresConnection: PostgresConnectionSchema,
+      },
+      async ({
+        manifestSlug,
+        newConnectionSlug,
+        postgresConnection,
+        shouldReplaceIfConnectionExists,
+      }) => {
+        const workspace = mcp.state.workspace;
+        const manifestWithPath = getManifestBySlug(workspace, manifestSlug);
+
+        if (!manifestWithPath) {
+          return {
+            content: [{ type: "text", text: `Manifest with slug '${manifestSlug}' not found.` }],
+          };
+        }
+
+        const { manifest, path } = manifestWithPath;
+        const manifestAbsolutePath = join(workspace.rootPath, path);
+
+        const existingConnection = (manifest.connections ?? []).find(
+          (conn) => conn.slug === newConnectionSlug,
+        );
+
+        if (existingConnection && !shouldReplaceIfConnectionExists) {
+          return {
+            content: [
+              {
+                type: "text",
+                text:
+                  `Connection with slug '${newConnectionSlug}' already exists in manifest '${manifestSlug}'.` +
+                  `Use the 'shouldReplaceIfConnectionExists' flag to replace it.`,
+              },
+            ],
+          };
+        }
+
+        if (!manifest.connections) {
+          manifest.connections = [];
+        }
+
+        if (existingConnection) {
+          manifest.connections = manifest.connections.filter((c) => c.slug !== newConnectionSlug);
+        }
+
+        manifest.connections.push({
+          slug: newConnectionSlug,
+          config: postgresConnection,
+        });
+
+        await writeManifest(manifest, manifestAbsolutePath);
+
+        return {
+          content: [
+            {
+              type: "text",
+              text:
+                `Added postgres connection to manifest '${manifestSlug}' with path '${path}'.` +
+                `It is now recommended to check connection health for the new connection '${newConnectionSlug}'.`,
+            },
+          ],
+        };
+      },
+    );
+  }
+}

--- a/apps/mcp/tools/manifest/manifest-info.tool.ts
+++ b/apps/mcp/tools/manifest/manifest-info.tool.ts
@@ -4,6 +4,8 @@ import { readManifest } from "@rejot-dev/contract-tools/manifest";
 import { verifyManifests } from "@rejot-dev/contract/manifest";
 import type { IRejotMcp, IFactory } from "@/rejot-mcp";
 import type { McpState } from "@/state/mcp-state";
+import { join } from "node:path";
+import { ensurePathRelative } from "@/util/fs.util";
 
 export class ManifestInfoTool implements IFactory {
   async initialize(_state: McpState): Promise<void> {
@@ -28,9 +30,13 @@ export class ManifestInfoTool implements IFactory {
       "mcp_rejot_mcp_manifest_info",
       "Get information about a specific manifest",
       {
-        manifestAbsoluteFilePath: z.string(),
+        relativeManifestFilePath: z.string(),
       },
-      async ({ manifestAbsoluteFilePath }) => {
+      async ({ relativeManifestFilePath }) => {
+        ensurePathRelative(relativeManifestFilePath);
+
+        const manifestAbsoluteFilePath = join(mcp.state.projectDir, relativeManifestFilePath);
+
         try {
           const manifest = await readManifest(manifestAbsoluteFilePath);
           const errors = verifyManifests([manifest]);

--- a/apps/mcp/util/fs.util.ts
+++ b/apps/mcp/util/fs.util.ts
@@ -1,0 +1,24 @@
+import { ReJotMcpError } from "@/state/mcp-error";
+import { isAbsolute } from "node:path";
+export class PathNotRelativeError extends ReJotMcpError {
+  #path: string;
+
+  get name(): string {
+    return "PathNotRelativeError";
+  }
+
+  get path(): string {
+    return this.#path;
+  }
+
+  constructor(path: string) {
+    super(`The path ${path} is not relative to the project directory.`);
+    this.#path = path;
+  }
+}
+
+export function ensurePathRelative(path: string): void {
+  if (isAbsolute(path)) {
+    throw new PathNotRelativeError(path);
+  }
+}

--- a/apps/mcp/workspace/workspace.resources.ts
+++ b/apps/mcp/workspace/workspace.resources.ts
@@ -16,13 +16,13 @@ export class WorkspaceResources implements IFactory {
   }
 
   async initialize(state: McpState): Promise<void> {
-    log.info("WorkspaceResources initialize", {
-      projectDir: state.projectDir,
-    });
-
     const { workspace, syncManifest } = await this.#workspaceService.initWorkspace(
       state.projectDir,
     );
+
+    log.info("WorkspaceResources initialized", {
+      workspace,
+    });
 
     state.setWorkspace(workspace);
     state.setSyncManifest(syncManifest);

--- a/apps/mcp/workspace/workspace.ts
+++ b/apps/mcp/workspace/workspace.ts
@@ -1,9 +1,6 @@
 import type { IManifestWorkspaceResolver, Workspace } from "@rejot-dev/contract-tools/manifest";
 import type { SyncManifest } from "@rejot-dev/contract/sync-manifest";
-import { getLogger } from "@rejot-dev/contract/logger";
 import { ReJotMcpError } from "@/state/mcp-error";
-
-const log = getLogger("mcp.workspace");
 
 export interface IWorkspaceService {
   initWorkspace(projectDir: string): Promise<{ workspace: Workspace; syncManifest: SyncManifest }>;
@@ -30,12 +27,6 @@ export class WorkspaceService implements IWorkspaceService {
         "Create a new manifest if this is a new workspace",
       );
     }
-
-    log.info("Workspace resolved", {
-      rootPath: workspace.rootPath,
-      ancestor: workspace.ancestor.path,
-      children: workspace.children.map((c) => c.path),
-    });
 
     try {
       const syncManifest = this.#workspaceResolver.workspaceToSyncManifest(workspace);

--- a/packages/contract-tools/manifest/manifest.fs.test.ts
+++ b/packages/contract-tools/manifest/manifest.fs.test.ts
@@ -1,0 +1,44 @@
+import { test, expect, beforeAll, afterAll } from "bun:test";
+import { initManifest, readManifest, writeManifest } from "./manifest.fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+let tempDir: string;
+let manifestPath: string;
+
+beforeAll(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "rejot-test-"));
+  manifestPath = join(tempDir, "rejot-manifest.json");
+  await initManifest(manifestPath, "test-manifest");
+});
+
+afterAll(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+test("writeManifest - overrides manifest", async () => {
+  const manifest = await readManifest(manifestPath);
+
+  expect(manifest.slug).toBe("test-manifest");
+
+  manifest.connections = [
+    {
+      slug: "test-connection",
+      config: {
+        connectionType: "postgres",
+        host: "localhost",
+        port: 5432,
+        user: "test",
+        password: "test",
+        database: "test",
+      },
+    },
+  ];
+
+  await writeManifest(manifest, manifestPath);
+
+  const manifest2 = await readManifest(manifestPath);
+
+  expect(manifest2.connections).toEqual(manifest.connections);
+});


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Added functionality to create and manage database connections in the Model Context Protocol (MCP) system. This PR introduces tools to add Postgres connections to manifest files and includes integration tests for the new features.

**New Features**
- Created a new `ManifestConnectionTool` that allows adding Postgres connections to manifest files
- Added integration tests to verify manifest initialization and connection management
- Improved error handling and logging throughout the MCP system

<!-- End of auto-generated description by mrge. -->

