### PR TITLE
MCP: add simple integration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,12 @@ jobs:
           REJOT_SYNC_CLI_TEST_CONNECTION: postgresql://postgres:postgres@localhost:5432/test
         run: bun test
 
+      - name: Run mcp integration test
+        working-directory: apps/mcp
+        env:
+          REJOT_SYNC_CLI_TEST_CONNECTION: postgresql://postgres:postgres@localhost:5432/test
+        run: bun test _test/mcp.integration.test.ts
+
   build-rejot-cli-image:
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest

--- a/apps/mcp/.env.example
+++ b/apps/mcp/.env.example
@@ -1,0 +1,2 @@
+# Rename to .env.local or .env.test
+REJOT_SYNC_CLI_TEST_CONNECTION=postgresql://postgres:postgres@localhost:5432/test

--- a/apps/mcp/.gitignore
+++ b/apps/mcp/.gitignore
@@ -1,1 +1,2 @@
 *.log
+.env.test

--- a/apps/mcp/_test/mcp.integration.test.ts
+++ b/apps/mcp/_test/mcp.integration.test.ts
@@ -1,0 +1,147 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { parsePostgresConnectionString } from "@rejot-dev/adapter-postgres/postgres-client";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+
+interface ToolResponse {
+  content: Array<{
+    type: string;
+    text: string;
+    isError?: boolean;
+  }>;
+}
+
+const isToolResponse = (obj: unknown): obj is ToolResponse => {
+  if (typeof obj !== "object" || obj === null) return false;
+
+  const response = obj as Record<string, unknown>;
+  if (!Array.isArray(response.content)) return false;
+
+  return response.content.every((item) => {
+    if (typeof item !== "object" || item === null) return false;
+    const content = item as Record<string, unknown>;
+    return (
+      typeof content.type === "string" &&
+      typeof content.text === "string" &&
+      (content.isError === undefined || typeof content.isError === "boolean")
+    );
+  });
+};
+
+describe("MCP Integration Tests", () => {
+  let client: Client;
+  let tmpDir: string;
+  const MANIFEST_FILE = "rejot-manifest.json";
+
+  const assertToolCall = async <T extends ToolResponse>(
+    toolName: string,
+    args: Record<string, unknown>,
+  ): Promise<T> => {
+    const result = await client.callTool({
+      name: toolName,
+      arguments: args,
+    });
+
+    // Validate response structure
+    expect(isToolResponse(result), "Response does not match ToolResponse structure").toBe(true);
+
+    // After validation, we can safely assert the type
+    const typedResult = result as ToolResponse;
+
+    // Check that no content items have isError set to true
+    typedResult.content.forEach(
+      (item: { type: string; text: string; isError?: boolean }, index: number) => {
+        expect(item.isError, `Error in response content[${index}]: ${item.text}`).toBeFalsy();
+      },
+    );
+
+    return result as T;
+  };
+
+  beforeAll(async () => {
+    // Create temporary directory
+    tmpDir = await mkdtemp(join(tmpdir(), "mcp-integration-test-"));
+
+    // Initialize client
+    const transport = new StdioClientTransport({
+      command: "bun",
+      args: ["./index.ts", "--project", tmpDir],
+    });
+
+    client = new Client({
+      name: "integration-test-client",
+      version: "1.0.0",
+    });
+
+    await client.connect(transport);
+  });
+
+  afterAll(async () => {
+    await client.close();
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  // Ran only in Postgres test
+  test.skipIf(process.env.REJOT_SYNC_CLI_TEST_CONNECTION === undefined)(
+    "full MCP workflow",
+    async () => {
+      const connectionString = process.env.REJOT_SYNC_CLI_TEST_CONNECTION;
+      if (!connectionString) {
+        throw new Error("REJOT_SYNC_CLI_TEST_CONNECTION environment variable is required");
+      }
+      const pgConfig = parsePostgresConnectionString(connectionString);
+
+      // Initialize project
+      const initResult = await assertToolCall<ToolResponse>("mcp_rejot_mcp_manifest_init", {
+        relativeManifestFilePath: MANIFEST_FILE,
+        slug: "test-manifest",
+      });
+      expect(initResult.content[0].type).toBe("text");
+      expect(initResult.content[0].text).toContain("Created new manifest file");
+
+      // Add Postgres connection
+      const connectionResult = await assertToolCall<ToolResponse>(
+        "rejot_manifest_connection_add_postgres",
+        {
+          manifestSlug: "test-manifest",
+          newConnectionSlug: "test-postgres",
+          postgresConnection: {
+            connectionType: "postgres",
+            ...pgConfig,
+          },
+        },
+      );
+      expect(connectionResult.content[0].type).toBe("text");
+
+      // Get manifest info
+      const infoResult = await assertToolCall<ToolResponse>("mcp_rejot_mcp_manifest_info", {
+        relativeManifestFilePath: MANIFEST_FILE,
+      });
+      expect(infoResult.content[0].type).toBe("text");
+      expect(infoResult.content[0].text).toContain("test-postgres"); // Verify connection is listed in the manifest info
+
+      // Check database health
+      const healthResult = await assertToolCall<ToolResponse>("mcp_rejot_db_check_health", {
+        connectionSlug: "test-postgres",
+      });
+      expect(healthResult.content[0].type).toBe("text");
+
+      // Remove connection
+      const removeResult = await assertToolCall<ToolResponse>("rejot_manifest_connection_remove", {
+        manifestSlug: "test-manifest",
+        connectionSlug: "test-postgres",
+      });
+      expect(removeResult.content[0].type).toBe("text");
+
+      // Verify connection was removed
+      const finalInfoResult = await assertToolCall<ToolResponse>("mcp_rejot_mcp_manifest_info", {
+        relativeManifestFilePath: MANIFEST_FILE,
+      });
+      expect(finalInfoResult.content[0].type).toBe("text");
+      expect(finalInfoResult.content[0].text).not.toContain("test-postgres"); // Verify connection is no longer listed
+    },
+  );
+});

--- a/apps/mcp/tools/manifest-connection/manifest-connection.tool.ts
+++ b/apps/mcp/tools/manifest-connection/manifest-connection.tool.ts
@@ -83,5 +83,65 @@ export class ManifestConnectionTool implements IFactory {
         };
       },
     );
+
+    mcp.registerTool(
+      "rejot_manifest_connection_remove",
+      "Remove a connection from the specified manifest.",
+      {
+        manifestSlug: z.string(),
+        connectionSlug: z.string(),
+      },
+      async ({ manifestSlug, connectionSlug }) => {
+        const workspace = mcp.state.workspace;
+        const manifestWithPath = getManifestBySlug(workspace, manifestSlug);
+
+        if (!manifestWithPath) {
+          return {
+            content: [{ type: "text", text: `Manifest with slug '${manifestSlug}' not found.` }],
+          };
+        }
+
+        const { manifest, path } = manifestWithPath;
+        const manifestAbsolutePath = join(workspace.rootPath, path);
+
+        if (!manifest.connections?.length) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `No connections found in manifest '${manifestSlug}'.`,
+              },
+            ],
+          };
+        }
+
+        const existingConnection = manifest.connections.find(
+          (conn) => conn.slug === connectionSlug,
+        );
+
+        if (!existingConnection) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Connection with slug '${connectionSlug}' not found in manifest '${manifestSlug}'.`,
+              },
+            ],
+          };
+        }
+
+        manifest.connections = manifest.connections.filter((c) => c.slug !== connectionSlug);
+        await writeManifest(manifest, manifestAbsolutePath);
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Successfully removed connection '${connectionSlug}' from manifest '${manifestSlug}'.`,
+            },
+          ],
+        };
+      },
+    );
   }
 }


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Added integration tests for the Model Context Protocol (MCP) to validate the full workflow from manifest creation to connection management.

**New Features**
- Created a comprehensive integration test that verifies manifest initialization, Postgres connection management, and database health checks
- Added a new tool method `rejot_manifest_connection_remove` to support connection removal in the test workflow

<!-- End of auto-generated description by mrge. -->

