### PR TITLE
MCP: Preparation for workspace manifest

### DIFF
--- a/apps/mcp/index.ts
+++ b/apps/mcp/index.ts
@@ -7,8 +7,9 @@ import { DbIntrospectionTool } from "./tools/db-introspection/db-introspection.t
 import { ManifestInfoTool } from "./tools/manifest/manifest-info.tool";
 import { ManifestInitTool } from "./tools/manifest/manifest-init.tool";
 import { setLogger, FileLogger } from "@rejot-dev/contract/logger";
-import { WorkspaceService } from "./workspace/workspace";
+import { WorkspaceService } from "../../packages/contract/workspace/workspace";
 import { ManifestConnectionTool } from "./tools/manifest-connection/manifest-connection.tool";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 // Open the log file when starting up
 const args = parseArgs(process.argv.slice(2));
@@ -22,7 +23,31 @@ const log = setLogger(new FileLogger(join(args.project, "mcp.log"), "DEBUG"));
 
 const workspaceService = new WorkspaceService(new ManifestWorkspaceResolver());
 
-const rejotMcp = new RejotMcp(args.project, log, [
+const server = new McpServer(
+  {
+    name: "@rejot-dev/mcp",
+    version: "0.0.7",
+  },
+  {
+    instructions: `
+This is the ReJot MCP server. ReJot provides a set of tools to facilitate micro-service
+communication. As opposed to traditional approaches like REST APIs, ReJot operates on the database
+layer.
+
+In the ReJot manifest, teams define their database connection details, as well as the entities they
+publish to other teams. These are called 'public schemas' and they're strongly tied to a version and
+contract. Other teams can subscribe to these schemas using a consumer schema.
+
+ALWAYS use the tools in this MCP to edit the manifest.
+
+- In most cases it makes sense to get the workspace's manifest information first.
+- If you do not know a connection's slug. Get the workspace manifest first.
+- You don't have to check health before doing other operations.
+      `,
+  },
+);
+
+const rejotMcp = new RejotMcp(args.project, server, [
   new WorkspaceResources(workspaceService),
   new DbIntrospectionTool(),
   new ManifestInfoTool(),

--- a/apps/mcp/state/mcp-state.ts
+++ b/apps/mcp/state/mcp-state.ts
@@ -1,11 +1,8 @@
 import type { Workspace } from "@rejot-dev/contract-tools/manifest";
 import type { SyncManifest } from "@rejot-dev/contract/sync-manifest";
-import {
-  WorkspaceNotInitializedError,
-  type ReJotMcpError,
-  CombinedRejotMcpError,
-} from "./mcp-error";
+import { WorkspaceNotInitializedError, CombinedRejotMcpError } from "./mcp-error";
 import { getLogger } from "@rejot-dev/contract/logger";
+import type { ReJotError } from "@rejot-dev/contract/error";
 
 const log = getLogger("mcp.state");
 
@@ -13,7 +10,7 @@ export type McpStateStatus = "uninitialized" | "initializing" | "ready" | "error
 
 export class McpState {
   readonly projectDir: string;
-  #initializationErrors: ReJotMcpError[] = [];
+  #initializationErrors: ReJotError[] = [];
 
   // Core state
   #workspace: Workspace | undefined;
@@ -45,7 +42,7 @@ export class McpState {
     return this.#syncManifest;
   }
 
-  get initializationErrors(): ReJotMcpError[] {
+  get initializationErrors(): ReJotError[] {
     return this.#initializationErrors;
   }
 
@@ -61,7 +58,7 @@ export class McpState {
     this.#syncManifest = syncManifest;
   }
 
-  addInitializationError(error: ReJotMcpError): void {
+  addInitializationError(error: ReJotError): void {
     this.#initializationErrors.push(error);
   }
 

--- a/apps/mcp/tools/db-introspection/db-introspection.tool.ts
+++ b/apps/mcp/tools/db-introspection/db-introspection.tool.ts
@@ -30,7 +30,7 @@ export class DbIntrospectionTool implements IFactory {
     //
   }
 
-  #getOrSetAdapter(connectionType: ValidConnectionType, state: McpState): AdapterPair {
+  #getOrSetAdapter(connectionType: ValidConnectionType): AdapterPair {
     const adapter = this.#adapters.get(connectionType);
     if (adapter) {
       return adapter;
@@ -40,7 +40,7 @@ export class DbIntrospectionTool implements IFactory {
     //              in the future we should resolve this based on installed dependencies / manifest.
 
     if (connectionType === "postgres") {
-      const postgresConnectionAdapter = new PostgresConnectionAdapter(state.syncManifest);
+      const postgresConnectionAdapter = new PostgresConnectionAdapter();
       const postgresIntrospectionAdapter = new PostgresIntrospectionAdapter(
         postgresConnectionAdapter,
       );
@@ -61,7 +61,7 @@ export class DbIntrospectionTool implements IFactory {
       throw new ConnectionNotFoundError(connectionSlug);
     }
 
-    const adapter = this.#getOrSetAdapter(manifestConnection.config.connectionType, state);
+    const adapter = this.#getOrSetAdapter(manifestConnection.config.connectionType);
     const connection = adapter.connectionAdapter.getOrCreateConnection(
       connectionSlug,
       manifestConnection.config,
@@ -261,18 +261,12 @@ export class ConnectionNotFoundError extends ReJotMcpError {
     this.#connectionSlug = connectionSlug;
   }
 
-  get connectionSlug(): string {
-    return this.#connectionSlug;
+  get name(): string {
+    return "ConnectionNotFoundError";
   }
 
-  toCallToolContent(): CallToolResult["content"] {
-    return [
-      {
-        isError: true,
-        type: "text",
-        text: this.message,
-      },
-    ];
+  get connectionSlug(): string {
+    return this.#connectionSlug;
   }
 }
 
@@ -282,6 +276,10 @@ export class AdapterNotFoundError extends ReJotMcpError {
   constructor(connectionType: ValidConnectionType) {
     super(`No adapter found for connection type: ${connectionType}`);
     this.#connectionType = connectionType;
+  }
+
+  get name(): string {
+    return "AdapterNotFoundError";
   }
 
   get connectionType(): ValidConnectionType {

--- a/apps/mcp/tools/manifest/manifest-info.tool.ts
+++ b/apps/mcp/tools/manifest/manifest-info.tool.ts
@@ -42,21 +42,9 @@ export class ManifestInfoTool implements IFactory {
           const errors = verifyManifests([manifest]);
 
           if (!errors.isValid) {
-            const errorMessages = errors.errors.map((error) => {
-              let message = `  - ${error.message}`;
-              if (error.hint) {
-                message += `\n      Hint: ${error.hint.message}`;
-                if (error.hint.suggestions) {
-                  message += `\n      Suggestions: ${error.hint.suggestions}`;
-                }
-              }
-              return message;
-            });
-
+            const errorOutput = ManifestPrinter.printManifestErrors(errors);
             return {
-              content: [
-                { type: "text", text: "Manifest contains errors:\n" + errorMessages.join("\n\n") },
-              ],
+              content: [{ type: "text", text: errorOutput.join("\n") }],
             };
           }
 

--- a/apps/mcp/tools/manifest/manifest-init.tool.ts
+++ b/apps/mcp/tools/manifest/manifest-init.tool.ts
@@ -2,9 +2,9 @@ import { z } from "zod";
 import { initManifest } from "@rejot-dev/contract-tools/manifest";
 import type { IRejotMcp, IFactory } from "@/rejot-mcp";
 import type { McpState } from "@/state/mcp-state";
-import type { IWorkspaceService } from "@/workspace/workspace";
 import { dirname, join } from "node:path";
 import { ensurePathRelative } from "@/util/fs.util";
+import type { IWorkspaceService } from "@rejot-dev/contract/workspace";
 
 export class ManifestInitTool implements IFactory {
   readonly #workspaceService: IWorkspaceService;
@@ -36,7 +36,7 @@ export class ManifestInitTool implements IFactory {
 
         try {
           await initManifest(manifestAbsoluteFilePath, slug);
-          const { workspace, syncManifest } = await this.#workspaceService.initWorkspace(
+          const { workspace, syncManifest } = await this.#workspaceService.resolveWorkspace(
             dirname(manifestAbsoluteFilePath),
           );
 

--- a/apps/mcp/workspace/workspace.resources.test.ts
+++ b/apps/mcp/workspace/workspace.resources.test.ts
@@ -7,7 +7,8 @@ import type {
   ManifestInfo,
 } from "@rejot-dev/contract-tools/manifest";
 import { workspaceToSyncManifest } from "@rejot-dev/contract-tools/manifest/manifest-workspace-resolver";
-import { WorkspaceService } from "./workspace";
+import { WorkspaceService } from "@rejot-dev/contract/workspace";
+
 // Create a sample manifest
 const createBasicManifest = (slug: string) => ({
   slug,
@@ -131,7 +132,6 @@ describe("WorkspaceResources", () => {
     expect(resources.length).toBe(1);
     expect(resources[0].name).toBe("ReJot Manifests");
 
-    // Our improved MockMcpServer implementation now correctly reads the URI template
     expect(resources[0].template.uri).toBe("rejot://workspace/{+path}");
   });
 

--- a/apps/mcp/workspace/workspace.resources.ts
+++ b/apps/mcp/workspace/workspace.resources.ts
@@ -1,11 +1,10 @@
-import type { IRejotMcp, IFactory } from "@/rejot-mcp";
 import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { join } from "node:path";
 import { readFile } from "node:fs/promises";
-import type { McpState } from "@/state/mcp-state";
 import { getLogger } from "@rejot-dev/contract/logger";
-import type { IWorkspaceService } from "./workspace";
-
+import type { IWorkspaceService } from "@rejot-dev/contract/workspace";
+import type { IFactory, IRejotMcp } from "../rejot-mcp";
+import type { McpState } from "../state/mcp-state";
 const log = getLogger("mcp.workspace.resources");
 
 export class WorkspaceResources implements IFactory {
@@ -16,7 +15,7 @@ export class WorkspaceResources implements IFactory {
   }
 
   async initialize(state: McpState): Promise<void> {
-    const { workspace, syncManifest } = await this.#workspaceService.initWorkspace(
+    const { workspace, syncManifest } = await this.#workspaceService.resolveWorkspace(
       state.projectDir,
     );
 

--- a/apps/rejot-cli/src/commands/manifest/manifest-info.command.ts
+++ b/apps/rejot-cli/src/commands/manifest/manifest-info.command.ts
@@ -47,16 +47,9 @@ export class ManifestInfoCommand extends Command {
       const errors = verifyManifests([manifest]);
 
       if (!errors.isValid) {
-        this.log("Manifest contains errors:");
-        for (const error of errors.errors) {
-          this.log(`  - ${error.message}`);
-          if (error.hint) {
-            this.log(`      Hint: ${error.hint.message}`);
-            if (error.hint.suggestions) {
-              this.log(`      Suggestions: ${error.hint.suggestions}`);
-            }
-          }
-          this.log("");
+        const errorOutput = ManifestPrinter.printManifestErrors(errors);
+        for (const line of errorOutput) {
+          this.log(line);
         }
         this.exit(1);
       }

--- a/apps/rejot-cli/src/commands/manifest/manifest-sync.command.ts
+++ b/apps/rejot-cli/src/commands/manifest/manifest-sync.command.ts
@@ -89,7 +89,7 @@ export class ManifestSyncCommand extends Command {
       const syncManifest = new SyncManifest(manifests);
 
       // Create adapters
-      const postgresAdapter = new PostgresConnectionAdapter(syncManifest);
+      const postgresAdapter = new PostgresConnectionAdapter();
       const transformationAdapter = new PostgresPublicSchemaTransformationAdapter(postgresAdapter);
       const consumerTransformationAdapter = new PostgresConsumerSchemaTransformationAdapter(
         postgresAdapter,

--- a/packages/adapter-postgres/src/adapter/pg-connection-adapter.ts
+++ b/packages/adapter-postgres/src/adapter/pg-connection-adapter.ts
@@ -7,7 +7,6 @@ import { DEFAULT_PUBLICATION_NAME, DEFAULT_SLOT_NAME } from "../postgres-consts.
 import { PostgresEventStore } from "../event-store/postgres-event-store.ts";
 import { PostgresClient } from "../util/postgres-client.ts";
 import { PostgresSink } from "../postgres-sink.ts";
-import type { SyncManifest } from "@rejot-dev/contract/sync-manifest";
 import type { IConnection } from "@rejot-dev/contract/sync";
 
 export interface PostgresConnection extends IConnection<z.infer<typeof PostgresConnectionSchema>> {
@@ -23,13 +22,7 @@ export class PostgresConnectionAdapter
       PostgresEventStore
     >
 {
-  #manifest: SyncManifest;
-
   #connections: Map<string, PostgresConnection> = new Map();
-
-  constructor(manifest: SyncManifest) {
-    this.#manifest = manifest;
-  }
 
   get connectionType(): "postgres" {
     return "postgres";
@@ -65,10 +58,7 @@ export class PostgresConnectionAdapter
     connectionSlug: string,
     connection: z.infer<typeof PostgresConnectionSchema>,
   ): PostgresEventStore {
-    return new PostgresEventStore(
-      this.getOrCreateConnection(connectionSlug, connection).client,
-      this.#manifest,
-    );
+    return new PostgresEventStore(this.getOrCreateConnection(connectionSlug, connection).client);
   }
 
   getConnection(connectionSlug: string): PostgresConnection | undefined {

--- a/packages/adapter-postgres/src/adapter/pg-consumer-schema-transformation-adapter.test.ts
+++ b/packages/adapter-postgres/src/adapter/pg-consumer-schema-transformation-adapter.test.ts
@@ -6,10 +6,8 @@ import { z } from "zod";
 import type { OperationTransformationPair } from "@rejot-dev/contract/adapter";
 import type { PostgresConsumerSchemaTransformationSchema } from "../postgres-schemas";
 import { PostgresConsumerDataStoreSchemaManager } from "../data-store/pg-consumer-data-store-schema-manager";
-import { SyncManifest } from "@rejot-dev/contract/sync-manifest";
 
 pgRollbackDescribe("PostgresConsumerSchemaTransformationAdapter", (ctx) => {
-  let syncManifest: SyncManifest;
   let connectionAdapter: PostgresConnectionAdapter;
 
   beforeEach(async () => {
@@ -21,30 +19,7 @@ pgRollbackDescribe("PostgresConsumerSchemaTransformationAdapter", (ctx) => {
       ...getTestConnectionConfig(),
     };
 
-    syncManifest = new SyncManifest([
-      {
-        slug: "test-manifest",
-        manifestVersion: 0,
-        connections: [
-          {
-            slug: "test-connection",
-            config: connectionConfig,
-          },
-        ],
-        dataStores: [
-          {
-            connectionSlug: "test-connection",
-            publicationName: "test-publication",
-            slotName: "test-slot",
-          },
-        ],
-        eventStores: [],
-        publicSchemas: [],
-        consumerSchemas: [],
-      },
-    ]);
-
-    connectionAdapter = new PostgresConnectionAdapter(syncManifest);
+    connectionAdapter = new PostgresConnectionAdapter();
     connectionAdapter.setConnection("test-connection", connectionConfig, ctx.client);
 
     // Insert some test data for schemas

--- a/packages/adapter-postgres/src/adapter/pg-introspection-adapter.test.ts
+++ b/packages/adapter-postgres/src/adapter/pg-introspection-adapter.test.ts
@@ -2,13 +2,11 @@ import { test, expect, beforeEach } from "bun:test";
 import { getTestConnectionConfig, pgRollbackDescribe } from "../util/postgres-test-utils";
 import { PostgresIntrospectionAdapter } from "./pg-introspection-adapter";
 import { PostgresConnectionAdapter } from "./pg-connection-adapter";
-import { SyncManifest } from "@rejot-dev/contract/sync-manifest";
 
 pgRollbackDescribe("PostgresIntrospectionAdapter", (ctx) => {
   let adapter: PostgresIntrospectionAdapter;
   let connectionAdapter: PostgresConnectionAdapter;
   let testConfig: ReturnType<typeof getTestConnectionConfig> & { connectionType: "postgres" };
-  let syncManifest: SyncManifest;
   const connectionSlug = "test-connection";
 
   beforeEach(async () => {
@@ -17,28 +15,7 @@ pgRollbackDescribe("PostgresIntrospectionAdapter", (ctx) => {
       ...getTestConnectionConfig(),
     };
 
-    // Create a basic manifest for testing
-    syncManifest = new SyncManifest([
-      {
-        slug: "test-manifest",
-        manifestVersion: 1,
-        connections: [
-          {
-            slug: connectionSlug,
-            config: {
-              ...testConfig,
-              connectionType: "postgres",
-            },
-          },
-        ],
-        dataStores: [],
-        eventStores: [],
-        publicSchemas: [],
-        consumerSchemas: [],
-      },
-    ]);
-
-    connectionAdapter = new PostgresConnectionAdapter(syncManifest);
+    connectionAdapter = new PostgresConnectionAdapter();
     connectionAdapter.setConnection(connectionSlug, testConfig, ctx.client);
 
     adapter = new PostgresIntrospectionAdapter(connectionAdapter);

--- a/packages/adapter-postgres/src/event-store/postgres-event-store.test.ts
+++ b/packages/adapter-postgres/src/event-store/postgres-event-store.test.ts
@@ -7,34 +7,10 @@ import type {
 } from "@rejot-dev/contract/event-store";
 import { pgRollbackDescribe } from "../util/postgres-test-utils";
 import { PostgresEventStore } from "./postgres-event-store";
-import { SyncManifest } from "@rejot-dev/contract/sync-manifest";
 import type { PublicSchemaReference } from "@rejot-dev/contract/cursor";
 
 const TEST_SCHEMA_NAME = "rejot_events";
 const TEST_TABLE_NAME = "events";
-
-const TEST_MANIFEST = {
-  slug: "test-manifest",
-  manifestVersion: 1,
-  connections: [
-    {
-      slug: "test-store-1",
-      config: {
-        connectionType: "in-memory" as const,
-      },
-    },
-    {
-      slug: "test-store-2",
-      config: {
-        connectionType: "in-memory" as const,
-      },
-    },
-  ],
-  dataStores: [{ connectionSlug: "test-store-1" }, { connectionSlug: "test-store-2" }],
-  eventStores: [],
-  publicSchemas: [],
-  consumerSchemas: [],
-};
 
 const TEST_SCHEMA: PublicSchemaReference = {
   manifest: {
@@ -48,7 +24,7 @@ const TEST_SCHEMA: PublicSchemaReference = {
 
 pgRollbackDescribe("PostgreSQL Event Store tests", (ctx) => {
   beforeEach(async () => {
-    const store = new PostgresEventStore(ctx.client, new SyncManifest([TEST_MANIFEST]));
+    const store = new PostgresEventStore(ctx.client);
     await store.prepare();
   });
 
@@ -69,7 +45,7 @@ pgRollbackDescribe("PostgreSQL Event Store tests", (ctx) => {
   });
 
   test("should write and read operations across multiple data stores", async () => {
-    const store = new PostgresEventStore(ctx.client, new SyncManifest([TEST_MANIFEST]));
+    const store = new PostgresEventStore(ctx.client);
     await store.prepare();
 
     const testOps1: TransformedOperationWithSource[] = [
@@ -120,7 +96,7 @@ pgRollbackDescribe("PostgreSQL Event Store tests", (ctx) => {
   });
 
   test("should handle cursor-based pagination correctly", async () => {
-    const store = new PostgresEventStore(ctx.client, new SyncManifest([TEST_MANIFEST]));
+    const store = new PostgresEventStore(ctx.client);
     await store.prepare();
 
     // Write operations to both data stores
@@ -190,7 +166,7 @@ pgRollbackDescribe("PostgreSQL Event Store tests", (ctx) => {
   });
 
   test("should handle empty cursor and null cursor the same", async () => {
-    const store = new PostgresEventStore(ctx.client, new SyncManifest([TEST_MANIFEST]));
+    const store = new PostgresEventStore(ctx.client);
     await store.prepare();
 
     const testOp: TransformedOperationWithSource = {
@@ -215,7 +191,7 @@ pgRollbackDescribe("PostgreSQL Event Store tests", (ctx) => {
   });
 
   test("should enforce read limits", async () => {
-    const store = new PostgresEventStore(ctx.client, new SyncManifest([TEST_MANIFEST]));
+    const store = new PostgresEventStore(ctx.client);
     await store.prepare();
 
     // Should throw for invalid limits
@@ -229,7 +205,7 @@ pgRollbackDescribe("PostgreSQL Event Store tests", (ctx) => {
   });
 
   test("should handle delete operation with only entity's id", async () => {
-    const store = new PostgresEventStore(ctx.client, new SyncManifest([TEST_MANIFEST]));
+    const store = new PostgresEventStore(ctx.client);
     await store.prepare();
 
     const deleteOp: TransformedOperationWithSourceDelete = {

--- a/packages/adapter-postgres/src/event-store/postgres-event-store.ts
+++ b/packages/adapter-postgres/src/event-store/postgres-event-store.ts
@@ -2,7 +2,6 @@ import type { IEventStore, TransformedOperationWithSource } from "@rejot-dev/con
 import { getLogger } from "@rejot-dev/contract/logger";
 import { PostgresClient } from "../util/postgres-client";
 import { EventStoreSchemaManager } from "./pg-event-store-schema-manager";
-import type { SyncManifest } from "@rejot-dev/contract/sync-manifest";
 import { PostgresEventStoreRepository } from "./pg-event-store-repository";
 import type { Cursor, PublicSchemaReference } from "@rejot-dev/contract/cursor";
 import type { OperationMessage } from "@rejot-dev/contract/message-bus";
@@ -13,7 +12,7 @@ export class PostgresEventStore implements IEventStore {
   #client: PostgresClient;
   #schemaManager: EventStoreSchemaManager;
 
-  constructor(client: PostgresClient, _manifest: SyncManifest) {
+  constructor(client: PostgresClient) {
     this.#client = client;
     this.#schemaManager = new EventStoreSchemaManager(client);
   }

--- a/packages/contract-tools/manifest/manifest-printer.ts
+++ b/packages/contract-tools/manifest/manifest-printer.ts
@@ -105,4 +105,23 @@ export class ManifestPrinter {
 
     return output;
   }
+
+  static printManifestErrors(errors: {
+    errors: Array<{ message: string; hint?: { message: string; suggestions?: string } }>;
+  }): string[] {
+    const output: string[] = ["Manifest contains errors:"];
+
+    for (const error of errors.errors) {
+      let message = `  - ${error.message}`;
+      if (error.hint) {
+        message += `\n      Hint: ${error.hint.message}`;
+        if (error.hint.suggestions) {
+          message += `\n      Suggestions: ${error.hint.suggestions}`;
+        }
+      }
+      output.push(message);
+    }
+
+    return output;
+  }
 }

--- a/packages/contract/error/error.ts
+++ b/packages/contract/error/error.ts
@@ -1,0 +1,29 @@
+export interface ReJotErrorOptions {
+  hints?: string[];
+  cause?: unknown;
+}
+
+export abstract class ReJotError extends Error {
+  #hints: string[] = [];
+
+  abstract get name(): string;
+
+  constructor(message: string, options: ReJotErrorOptions = {}) {
+    super(message, { cause: options.cause });
+    this.#hints = options.hints ?? [];
+  }
+
+  withHint(hint: string): this {
+    this.#hints.push(hint);
+    return this;
+  }
+
+  withHints(hints: string[]): this {
+    this.#hints.push(...hints);
+    return this;
+  }
+
+  get hints(): Readonly<string[]> {
+    return this.#hints;
+  }
+}

--- a/packages/contract/manifest/manifest-helpers.ts
+++ b/packages/contract/manifest/manifest-helpers.ts
@@ -1,0 +1,176 @@
+import { z } from "zod";
+import type { SyncManifestSchema, ConsumerSchemaSchema, PublicSchemaSchema } from "./manifest";
+import type { TransformedOperationWithSource } from "@rejot-dev/contract/event-store";
+import type { Connection, SourceDataStore, DestinationDataStore, Operation } from "./sync-manifest";
+
+type Manifest = z.infer<typeof SyncManifestSchema>;
+
+// Helper functions extracted from SyncManifest
+
+export function getConnectionsHelper(manifests: Manifest[]): Connection[] {
+  return manifests.flatMap((manifest) => manifest.connections ?? []);
+}
+
+export function getDataStoresHelper(manifests: Manifest[]): NonNullable<Manifest["dataStores"]> {
+  return manifests.flatMap((manifest) => manifest.dataStores ?? []);
+}
+
+export function getEventStoresHelper(manifests: Manifest[]): NonNullable<Manifest["eventStores"]> {
+  return manifests.flatMap((manifest) => manifest.eventStores ?? []);
+}
+
+export function getConnectionBySlugHelper(
+  manifests: Manifest[],
+  connectionSlug: string,
+): Connection | undefined {
+  const connections = getConnectionsHelper(manifests);
+  const connection = connections.find((connection) => connection.slug === connectionSlug);
+
+  if (!connection) {
+    return undefined;
+  }
+
+  return {
+    slug: connection.slug,
+    config: connection.config,
+  };
+}
+
+export function getSourceDataStoresHelper(manifests: Manifest[]): SourceDataStore[] {
+  const dataStores = manifests
+    .flatMap((manifest) =>
+      (manifest.dataStores ?? []).map((ds) => ({
+        ...ds,
+        sourceManifestSlug: manifest.slug,
+      })),
+    )
+    .filter(
+      (
+        ds,
+      ): ds is {
+        connectionSlug: string;
+        publicationName: string;
+        slotName: string;
+        sourceManifestSlug: string;
+        // TODO: Type predicate only checks for publicationName and slotName but asserts a type
+        //       that includes more properties
+      } => Boolean(ds.publicationName && ds.slotName),
+    );
+
+  return dataStores.map((ds) => {
+    const connection = getConnectionBySlugHelper(manifests, ds.connectionSlug);
+    if (!connection) {
+      // This error should ideally be caught during verification, but keep for safety
+      throw new Error(`Connection '${ds.connectionSlug}' not found in manifests`);
+    }
+    return {
+      ...ds,
+      connection: {
+        slug: connection.slug,
+        config: connection.config,
+      },
+    };
+  });
+}
+
+export function getDestinationDataStoresHelper(manifests: Manifest[]): DestinationDataStore[] {
+  const slugs = Array.from(
+    new Set(
+      manifests.flatMap((manifest) =>
+        (manifest.consumerSchemas ?? []).map((cs) => cs.destinationDataStoreSlug),
+      ),
+    ),
+  );
+
+  return slugs.map((connectionSlug) => {
+    const connection = getConnectionBySlugHelper(manifests, connectionSlug);
+    if (!connection) {
+      // This error should ideally be caught during verification, but keep for safety
+      throw new Error(`Connection '${connectionSlug}' not found in manifests`);
+    }
+    return {
+      connectionSlug,
+      connection: {
+        slug: connection.slug,
+        config: connection.config,
+      },
+    };
+  });
+}
+
+export function getExternalConsumerSchemasHelper(
+  manifests: Manifest[],
+): Record<string, z.infer<typeof ConsumerSchemaSchema>[]> {
+  if (manifests.length === 0) {
+    return {};
+  }
+
+  const loadedManifestSlugs = new Set(manifests.map((m) => m.slug));
+  const result: Record<string, z.infer<typeof ConsumerSchemaSchema>[]> = {};
+
+  for (const manifest of manifests) {
+    for (const consumerSchema of manifest.consumerSchemas ?? []) {
+      if (!loadedManifestSlugs.has(consumerSchema.sourceManifestSlug)) {
+        if (!result[consumerSchema.sourceManifestSlug]) {
+          result[consumerSchema.sourceManifestSlug] = [];
+        }
+        result[consumerSchema.sourceManifestSlug].push(consumerSchema);
+      }
+    }
+  }
+
+  return result;
+}
+
+export function getConsumerSchemasForPublicSchemaHelper(
+  manifests: Manifest[],
+  operation: TransformedOperationWithSource,
+): z.infer<typeof ConsumerSchemaSchema>[] {
+  return manifests.flatMap((manifest) =>
+    (manifest.consumerSchemas ?? []).filter(
+      (consumerSchema) => consumerSchema.publicSchema.name === operation.sourcePublicSchema.name,
+    ),
+  );
+}
+
+export function getPublicSchemasForOperationHelper(
+  manifests: Manifest[],
+  dataStoreSlug: string,
+  operation: Operation,
+): (z.infer<typeof PublicSchemaSchema> & { source: { manifestSlug: string } })[] {
+  return manifests.flatMap((manifest) =>
+    (manifest.publicSchemas ?? [])
+      .filter((schema) => {
+        const dataStore = (manifest.dataStores ?? []).find(
+          (ds) => ds.connectionSlug === dataStoreSlug,
+        );
+        // Ensure dataStore exists and matches the source slug, and the operation table is included
+        return (
+          dataStore &&
+          schema.source.dataStoreSlug === dataStore.connectionSlug && // Match dataStoreSlug correctly
+          schema.source.tables.includes(operation.table)
+        );
+      })
+      .map(({ name, source, transformations, version, outputSchema }) => ({
+        name,
+        source: {
+          ...source,
+          manifestSlug: manifest.slug, // Add manifest slug to the source
+        },
+        transformations,
+        version,
+        outputSchema,
+      })),
+  );
+}
+
+export function getPublicSchemasHelper(
+  manifests: Manifest[],
+): (z.infer<typeof PublicSchemaSchema> & { manifestSlug: string })[] {
+  return manifests.flatMap((manifest) =>
+    (manifest.publicSchemas ?? []).map((schema) => ({
+      ...schema,
+      manifestSlug: manifest.slug,
+    })),
+  );
+}

--- a/packages/contract/manifest/sync-manifest.ts
+++ b/packages/contract/manifest/sync-manifest.ts
@@ -13,6 +13,18 @@ import {
 } from "./verify-manifest";
 import { getLogger } from "@rejot-dev/contract/logger";
 import type { TransformedOperationWithSource } from "@rejot-dev/contract/event-store";
+import {
+  getConnectionsHelper,
+  getDataStoresHelper,
+  getEventStoresHelper,
+  getConnectionBySlugHelper,
+  getSourceDataStoresHelper,
+  getDestinationDataStoresHelper,
+  getExternalConsumerSchemasHelper,
+  getConsumerSchemasForPublicSchemaHelper,
+  getPublicSchemasForOperationHelper,
+  getPublicSchemasHelper,
+} from "./manifest-helpers";
 
 const log = getLogger("sync-manifest");
 
@@ -41,16 +53,6 @@ export type ExternalConsumerSchemas = Array<[string, z.infer<typeof ConsumerSche
 export type Operation = {
   table: string;
 };
-
-export type Purpose =
-  /** Listens for changes in source data stores, and publishes them to an event store. */
-  | "SOURCE_LISTENER"
-  /** Listens for changes in an event store, and applies them to consumer schemas. */
-  | "EVENT_STORE_LISTENER"
-  /** Listens for changes in external sync services, and applies them to consumer schemas. */
-  | "EXTERNAL_SYNC_LISTENER"
-  /** Publishes an HTTP endpoint to allow others to sync from us. */
-  | "EVENT_STORE_PUBLISHER";
 
 export interface SyncManifestOptions {
   checkPublicSchemaReferences?: boolean;
@@ -90,86 +92,27 @@ export class SyncManifest {
   }
 
   get connections(): Connection[] {
-    return this.#manifests.flatMap((manifest) => manifest.connections ?? []);
+    return getConnectionsHelper(this.#manifests);
   }
 
   get dataStores(): NonNullable<Manifest["dataStores"]> {
-    return this.#manifests.flatMap((manifest) => manifest.dataStores ?? []);
+    return getDataStoresHelper(this.#manifests);
   }
 
   get eventStores(): NonNullable<Manifest["eventStores"]> {
-    return this.#manifests.flatMap((manifest) => manifest.eventStores ?? []);
+    return getEventStoresHelper(this.#manifests);
   }
 
   getSourceDataStores(): SourceDataStore[] {
-    const dataStores = this.#manifests
-      .flatMap((manifest) =>
-        (manifest.dataStores ?? []).map((ds) => ({
-          ...ds,
-          sourceManifestSlug: manifest.slug,
-        })),
-      )
-      .filter(
-        (
-          ds,
-        ): ds is {
-          connectionSlug: string;
-          publicationName: string;
-          slotName: string;
-          sourceManifestSlug: string;
-        } => Boolean(ds.publicationName && ds.slotName),
-      );
-
-    return dataStores.map((ds) => {
-      const connection = this.getConnectionBySlug(ds.connectionSlug);
-      if (!connection) {
-        throw new Error(`Connection '${ds.connectionSlug}' not found in manifests`);
-      }
-      return {
-        ...ds,
-        connection: {
-          slug: connection.slug,
-          config: connection.config,
-        },
-      };
-    });
+    return getSourceDataStoresHelper(this.#manifests);
   }
 
   getDestinationDataStores(): DestinationDataStore[] {
-    const slugs = Array.from(
-      new Set(
-        this.#manifests.flatMap((manifest) =>
-          (manifest.consumerSchemas ?? []).map((cs) => cs.destinationDataStoreSlug),
-        ),
-      ),
-    );
-
-    return slugs.map((connectionSlug) => {
-      const connection = this.getConnectionBySlug(connectionSlug);
-      if (!connection) {
-        throw new Error(`Connection '${connectionSlug}' not found in manifests`);
-      }
-      return {
-        connectionSlug,
-        connection: {
-          slug: connection.slug,
-          config: connection.config,
-        },
-      };
-    });
+    return getDestinationDataStoresHelper(this.#manifests);
   }
 
   getConnectionBySlug(connectionSlug: string): Connection | undefined {
-    const connection = this.connections.find((connection) => connection.slug === connectionSlug);
-
-    if (!connection) {
-      return undefined;
-    }
-
-    return {
-      slug: connection.slug,
-      config: connection.config,
-    };
+    return getConnectionBySlugHelper(this.#manifests, connectionSlug);
   }
 
   get hasUnresolvedExternalReferences(): boolean {
@@ -184,81 +127,24 @@ export class SyncManifest {
    * @throws Error if the internal state is inconsistent (e.g., referenced manifest or schema not found).
    */
   getExternalConsumerSchemas(): Record<string, z.infer<typeof ConsumerSchemaSchema>[]> {
-    // If we have no manifests loaded, return an empty result
-    if (this.#manifests.length === 0) {
-      return {};
-    }
-
-    // Get all the manifests' slugs for easy checking
-    const loadedManifestSlugs = new Set(this.#manifests.map((m) => m.slug));
-
-    // Collect all consumer schemas that reference external manifests
-    const result: Record<string, z.infer<typeof ConsumerSchemaSchema>[]> = {};
-
-    // Loop through all manifests and identify consumer schemas referencing external manifests
-    for (const manifest of this.#manifests) {
-      for (const consumerSchema of manifest.consumerSchemas ?? []) {
-        // Check if the sourceManifestSlug references a manifest not in our loaded set
-        if (!loadedManifestSlugs.has(consumerSchema.sourceManifestSlug)) {
-          // This is a reference to an external manifest
-          if (!result[consumerSchema.sourceManifestSlug]) {
-            result[consumerSchema.sourceManifestSlug] = [];
-          }
-
-          result[consumerSchema.sourceManifestSlug].push(consumerSchema);
-        }
-      }
-    }
-
-    return result;
+    return getExternalConsumerSchemasHelper(this.#manifests);
   }
 
   getConsumerSchemasForPublicSchema(
     operation: TransformedOperationWithSource,
   ): z.infer<typeof ConsumerSchemaSchema>[] {
-    return this.#manifests.flatMap((manifest) =>
-      (manifest.consumerSchemas ?? []).filter(
-        (consumerSchema) => consumerSchema.publicSchema.name === operation.sourcePublicSchema.name,
-      ),
-    );
+    return getConsumerSchemasForPublicSchemaHelper(this.#manifests, operation);
   }
 
   getPublicSchemasForOperation(
     dataStoreSlug: string,
     operation: Operation,
   ): (z.infer<typeof PublicSchemaSchema> & { source: { manifestSlug: string } })[] {
-    return this.#manifests.flatMap((manifest) =>
-      (manifest.publicSchemas ?? [])
-        .filter((schema) => {
-          const dataStore = (manifest.dataStores ?? []).find(
-            (ds) => ds.connectionSlug === dataStoreSlug,
-          );
-          return (
-            dataStore &&
-            schema.source.dataStoreSlug === dataStoreSlug &&
-            schema.source.tables.includes(operation.table)
-          );
-        })
-        .map(({ name, source, transformations, version, outputSchema }) => ({
-          name,
-          source: {
-            ...source,
-            manifestSlug: manifest.slug,
-          },
-          transformations,
-          version,
-          outputSchema,
-        })),
-    );
+    return getPublicSchemasForOperationHelper(this.#manifests, dataStoreSlug, operation);
   }
 
   getPublicSchemas(): (z.infer<typeof PublicSchemaSchema> & { manifestSlug: string })[] {
-    return this.#manifests.flatMap((manifest) =>
-      (manifest.publicSchemas ?? []).map((schema) => ({
-        ...schema,
-        manifestSlug: manifest.slug,
-      })),
-    );
+    return getPublicSchemasHelper(this.#manifests);
   }
 
   /**

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -26,6 +26,8 @@
     "./sync-manifest": "./manifest/sync-manifest.ts",
     "./postgres": "./postgres/postgres.ts",
     "./public-schema": "./public-schema/public-schema.ts",
+    "./workspace": "./workspace/workspace.ts",
+    "./error": "./error/error.ts",
     "./sync": "./sync/sync.ts",
     "./schema-validator": "./schema-validator.ts",
     "./message-bus": "./message-bus/message-bus.ts",


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Refactored MCP and contract packages to prepare for workspace manifest support, including new error handling, manifest helpers, and workspace service updates.

- **Refactors**
  - Moved workspace logic and error types to contract package.
  - Added manifest helper utilities for cleaner SyncManifest code.
  - Updated error handling to use a shared ReJotError base class.
  - Simplified adapter and event store interfaces to remove manifest coupling.

- **Bug Fixes**
  - Fixed manifest error reporting in CLI and MCP tools for clearer output.

<!-- End of auto-generated description by mrge. -->

