### PR TITLE
MCP: Make distinction between workspace and manifest clearer

### DIFF
--- a/apps/mcp/_test/mock-mcp-server.ts
+++ b/apps/mcp/_test/mock-mcp-server.ts
@@ -315,7 +315,7 @@ export class MockRejotMcp extends RejotMcp implements IRejotMcp {
     );
   }
 
-  get projectDir(): string {
+  get workspaceDirectoryPath(): string {
     return this.#projectDir;
   }
 

--- a/apps/mcp/index.ts
+++ b/apps/mcp/index.ts
@@ -5,11 +5,12 @@ import { WorkspaceResources } from "./workspace/workspace.resources";
 import { ManifestWorkspaceResolver } from "@rejot-dev/contract-tools/manifest";
 import { DbIntrospectionTool } from "./tools/db-introspection/db-introspection.tool";
 import { ManifestInfoTool } from "./tools/manifest/manifest-info.tool";
-import { ManifestInitTool } from "./tools/manifest/manifest-init.tool";
+import { WorkspaceTool } from "./workspace/workspace.tool";
 import { setLogger, FileLogger } from "@rejot-dev/contract/logger";
 import { WorkspaceService } from "../../packages/contract/workspace/workspace";
 import { ManifestConnectionTool } from "./tools/manifest-connection/manifest-connection.tool";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ManifestInitTool } from "./tools/manifest/manifest-init.tool";
 
 // Open the log file when starting up
 const args = parseArgs(process.argv.slice(2));
@@ -34,13 +35,17 @@ This is the ReJot MCP server. ReJot provides a set of tools to facilitate micro-
 communication. As opposed to traditional approaches like REST APIs, ReJot operates on the database
 layer.
 
+ReJot has the concept of a 'workspace'. A workspace is a collection of manifests. A workspace can
+and will usually contain multiple manifests. One root manifest defines the workspace, which will
+contain relative path references to manifests in sub-directories.
+
 In the ReJot manifest, teams define their database connection details, as well as the entities they
 publish to other teams. These are called 'public schemas' and they're strongly tied to a version and
 contract. Other teams can subscribe to these schemas using a consumer schema.
 
-ALWAYS use the tools in this MCP to edit the manifest.
-
-- In most cases it makes sense to get the workspace's manifest information first.
+Some tips:
+- ALWAYS use the tools in this MCP to edit the manifest.
+- Obtain the workspace information first.
 - If you do not know a connection's slug. Get the workspace manifest first.
 - You don't have to check health before doing other operations.
       `,
@@ -51,8 +56,9 @@ const rejotMcp = new RejotMcp(args.project, server, [
   new WorkspaceResources(workspaceService),
   new DbIntrospectionTool(),
   new ManifestInfoTool(),
-  new ManifestInitTool(workspaceService),
+  new WorkspaceTool(workspaceService),
   new ManifestConnectionTool(),
+  new ManifestInitTool(),
 ]);
 
 rejotMcp

--- a/apps/mcp/rejot-mcp.ts
+++ b/apps/mcp/rejot-mcp.ts
@@ -34,7 +34,7 @@ export interface IFactory {
  * Interface for RejotMcp to allow for mocking
  */
 export interface IRejotMcp {
-  projectDir: string;
+  workspaceDirectoryPath: string;
   server: IMcpServer;
   state: McpState;
   connect(transport: Transport): Promise<void>;
@@ -66,8 +66,8 @@ export class RejotMcp implements IRejotMcp {
     this.#server = server;
   }
 
-  get projectDir(): string {
-    return this.#state.projectDir;
+  get workspaceDirectoryPath(): string {
+    return this.#state.workspaceDirectoryPath;
   }
 
   get server(): IMcpServer {
@@ -176,9 +176,9 @@ export class RejotMcp implements IRejotMcp {
     // Only proceed with registration if state is ready
     await this.#register();
 
-    log.info(`ReJot MCP server initialized for project ${this.projectDir}`);
+    log.info(`ReJot MCP server initialized for project ${this.workspaceDirectoryPath}`);
     await this.#server.connect(transport);
-    log.info(`ReJot MCP server connected to ${this.projectDir}`);
+    log.info(`ReJot MCP server connected to ${this.workspaceDirectoryPath}`);
 
     if (this.#state.initializationErrors.length > 0) {
       log.warn("State initialization failed:");

--- a/apps/mcp/tools/db-introspection/db-introspection.tool.ts
+++ b/apps/mcp/tools/db-introspection/db-introspection.tool.ts
@@ -74,7 +74,7 @@ export class DbIntrospectionTool implements IFactory {
 
   async register(mcp: IRejotMcp): Promise<void> {
     mcp.registerTool(
-      "mcp_rejot_db_get_tables",
+      "rejot_db_get_tables",
       "Get all tables from a database connection",
       {
         connectionSlug: z.string().describe(CONNECTION_SLUG_DESCRIPTION),

--- a/apps/mcp/tools/manifest/manifest-info.tool.ts
+++ b/apps/mcp/tools/manifest/manifest-info.tool.ts
@@ -35,7 +35,10 @@ export class ManifestInfoTool implements IFactory {
       async ({ relativeManifestFilePath }) => {
         ensurePathRelative(relativeManifestFilePath);
 
-        const manifestAbsoluteFilePath = join(mcp.state.projectDir, relativeManifestFilePath);
+        const manifestAbsoluteFilePath = join(
+          mcp.state.workspaceDirectoryPath,
+          relativeManifestFilePath,
+        );
 
         try {
           const manifest = await readManifest(manifestAbsoluteFilePath);

--- a/apps/mcp/workspace/workspace.resources.test.ts
+++ b/apps/mcp/workspace/workspace.resources.test.ts
@@ -3,7 +3,7 @@ import { MockRejotMcp } from "../_test/mock-mcp-server";
 import { WorkspaceResources } from "./workspace.resources";
 import type {
   IManifestWorkspaceResolver,
-  Workspace,
+  WorkspaceDefinition,
   ManifestInfo,
 } from "@rejot-dev/contract-tools/manifest";
 import { workspaceToSyncManifest } from "@rejot-dev/contract-tools/manifest/manifest-workspace-resolver";
@@ -28,7 +28,9 @@ const createComplexManifest = (slug: string) => ({
 });
 
 // Create a mock of the IManifestWorkspaceResolver interface
-const createMockWorkspaceResolver = (testWorkspace: Workspace): IManifestWorkspaceResolver => {
+const createMockWorkspaceResolver = (
+  testWorkspace: WorkspaceDefinition,
+): IManifestWorkspaceResolver => {
   return {
     resolveWorkspace: mock(() => Promise.resolve(testWorkspace)),
     getManifestInfo: mock(
@@ -39,12 +41,14 @@ const createMockWorkspaceResolver = (testWorkspace: Workspace): IManifestWorkspa
           rootPath: "/test/root",
         }),
     ),
-    workspaceToSyncManifest: mock((workspace: Workspace) => workspaceToSyncManifest(workspace)),
+    workspaceToSyncManifest: mock((workspace: WorkspaceDefinition) =>
+      workspaceToSyncManifest(workspace),
+    ),
   };
 };
 
 // Helper to create a test workspace
-const createTestWorkspace = (): Workspace => ({
+const createTestWorkspace = (): WorkspaceDefinition => ({
   rootPath: "/test/root",
   ancestor: {
     path: "rejot-manifest.json",
@@ -59,7 +63,7 @@ const createTestWorkspace = (): Workspace => ({
 });
 
 // Helper to create a complex test workspace
-const createComplexTestWorkspace = (): Workspace => ({
+const createComplexTestWorkspace = (): WorkspaceDefinition => ({
   rootPath: "/complex/root",
   ancestor: {
     path: "rejot-manifest.json",

--- a/apps/mcp/workspace/workspace.resources.ts
+++ b/apps/mcp/workspace/workspace.resources.ts
@@ -15,8 +15,8 @@ export class WorkspaceResources implements IFactory {
   }
 
   async initialize(state: McpState): Promise<void> {
-    const { workspace, syncManifest } = await this.#workspaceService.resolveWorkspace(
-      state.projectDir,
+    const { workspace } = await this.#workspaceService.resolveWorkspace(
+      state.workspaceDirectoryPath,
     );
 
     log.info("WorkspaceResources initialized", {
@@ -24,7 +24,6 @@ export class WorkspaceResources implements IFactory {
     });
 
     state.setWorkspace(workspace);
-    state.setSyncManifest(syncManifest);
   }
 
   async register(mcp: IRejotMcp): Promise<void> {

--- a/apps/mcp/workspace/workspace.tool.ts
+++ b/apps/mcp/workspace/workspace.tool.ts
@@ -1,0 +1,93 @@
+import { z } from "zod";
+import { initManifest } from "@rejot-dev/contract-tools/manifest";
+import type { IRejotMcp, IFactory } from "@/rejot-mcp";
+import type { McpState } from "@/state/mcp-state";
+import { dirname, join } from "node:path";
+import type { IWorkspaceService } from "@rejot-dev/contract/workspace";
+import { ManifestPrinter } from "@rejot-dev/contract-tools/manifest/manifest-printer";
+import { getLogger } from "@rejot-dev/contract/logger";
+
+const log = getLogger(import.meta.url);
+
+export class WorkspaceTool implements IFactory {
+  readonly #workspaceService: IWorkspaceService;
+
+  constructor(workspaceService: IWorkspaceService) {
+    this.#workspaceService = workspaceService;
+  }
+
+  async initialize(_state: McpState): Promise<void> {
+    // No state initialization needed
+  }
+
+  async register(mcp: IRejotMcp): Promise<void> {
+    mcp.registerTool(
+      "rejot_workspace_init",
+      "Initialize a new ReJot workspace by creating a root manifest file.",
+      {
+        slug: z.string().describe("The slug for the root manifest (workspace). Usually `@org/`."),
+        fileName: z.string().default("rejot-manifest.json"),
+      },
+      async ({ slug, fileName }) => {
+        const manifestAbsoluteFilePath = join(mcp.state.workspaceDirectoryPath, fileName);
+
+        try {
+          await initManifest(manifestAbsoluteFilePath, slug, { workspace: true });
+          log.info(`Workspace initialized successfully at ${manifestAbsoluteFilePath}`);
+
+          const { workspace } = await this.#workspaceService.resolveWorkspace(
+            dirname(manifestAbsoluteFilePath),
+          );
+
+          mcp.state.setWorkspace(workspace);
+          mcp.state.clearInitializationErrors();
+
+          return {
+            content: [
+              { type: "text", text: `Workspace initialized successfully` },
+              // TODO: Explain next steps here maybe.
+            ],
+          };
+        } catch (error) {
+          if (error instanceof Error && "code" in error && error.code === "EEXIST") {
+            return {
+              content: [
+                {
+                  isError: true,
+                  type: "text",
+                  text: `Manifest/workspace file already exists at ${manifestAbsoluteFilePath}. Use a different path or remove the existing file.`,
+                },
+              ],
+            };
+          }
+          throw error;
+        }
+      },
+    );
+
+    mcp.registerTool(
+      "rejot_workspace_info",
+      "Display information about the current workspace configuration.",
+      {},
+      async () => {
+        log.debug("rejot_workspace_info", {
+          workspaceDirectoryPath: mcp.state.workspaceDirectoryPath,
+        });
+
+        const { workspace } = await this.#workspaceService.resolveWorkspace(
+          mcp.state.workspaceDirectoryPath,
+        );
+        const workspaceInfo = ManifestPrinter.printWorkspace(workspace);
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: workspaceInfo.join("\n"),
+            },
+          ],
+        };
+      },
+    );
+  }
+}

--- a/packages/contract-tools/manifest/index.ts
+++ b/packages/contract-tools/manifest/index.ts
@@ -1,9 +1,14 @@
 export { ManifestPrinter } from "./manifest-printer";
-export { readManifest, writeManifest, initManifest, findManifestPath } from "./manifest.fs";
+export {
+  readManifestOrGetEmpty as readManifest,
+  writeManifest,
+  initManifest,
+  findManifestPath,
+} from "./manifest.fs";
 export { ManifestWorkspaceResolver } from "./manifest-workspace-resolver";
 export type {
   IManifestWorkspaceResolver,
-  Workspace,
+  WorkspaceDefinition,
   ResolveWorkspaceOptions,
   ManifestInfo,
 } from "./manifest-workspace-resolver";

--- a/packages/contract-tools/manifest/manifest-workspace-resolver.test.ts
+++ b/packages/contract-tools/manifest/manifest-workspace-resolver.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ManifestWorkspaceResolver } from "./manifest-workspace-resolver";
+import { DEFAULT_MANIFEST_FILENAME, CURRENT_MANIFEST_FILE_VERSION } from "./manifest.fs";
+
+// Helper function to create manifest files
+const createManifestFile = async (
+  dirPath: string,
+  content: object,
+  filename = DEFAULT_MANIFEST_FILENAME,
+) => {
+  await mkdir(dirPath, { recursive: true });
+  await writeFile(join(dirPath, filename), JSON.stringify(content, null, 2));
+};
+
+describe("ManifestWorkspaceResolver", () => {
+  let tmpDir: string;
+  let resolver: ManifestWorkspaceResolver;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "manifest-resolver-test-"));
+    resolver = new ManifestWorkspaceResolver();
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  describe("resolveWorkspace", () => {
+    it("should return null if no manifest is found", async () => {
+      const result = await resolver.resolveWorkspace({ startDir: tmpDir });
+      expect(result).toBeNull();
+    });
+
+    it("should resolve only the ancestor if no workspaces field exists", async () => {
+      const manifestContent = {
+        slug: "root-project",
+        manifestVersion: CURRENT_MANIFEST_FILE_VERSION,
+      };
+      await createManifestFile(tmpDir, manifestContent);
+
+      const result = await resolver.resolveWorkspace({ startDir: tmpDir });
+
+      expect(result).not.toBeNull();
+      expect(result?.rootPath).toBe(tmpDir);
+      expect(result?.ancestor.path).toBe(DEFAULT_MANIFEST_FILENAME);
+      expect(result?.ancestor.manifest.slug).toBe("root-project");
+      expect(result?.children).toEqual([]);
+    });
+
+    it("should resolve only the ancestor if workspaces field is empty", async () => {
+      const manifestContent = {
+        slug: "root-project",
+        manifestVersion: CURRENT_MANIFEST_FILE_VERSION,
+        workspaces: [],
+      };
+      await createManifestFile(tmpDir, manifestContent);
+
+      const result = await resolver.resolveWorkspace({ startDir: tmpDir });
+
+      expect(result).not.toBeNull();
+      expect(result?.rootPath).toBe(tmpDir);
+      expect(result?.ancestor.manifest.slug).toBe("root-project");
+      expect(result?.children).toEqual([]);
+    });
+
+    it("should resolve ancestor and children with direct file paths", async () => {
+      const rootManifest = {
+        slug: "root",
+        manifestVersion: CURRENT_MANIFEST_FILE_VERSION,
+        workspaces: ["packages/pkg1/manifest.json", "packages/pkg2/manifest.json"],
+      };
+      const child1Manifest = { slug: "child1", manifestVersion: CURRENT_MANIFEST_FILE_VERSION };
+      const child2Manifest = { slug: "child2", manifestVersion: CURRENT_MANIFEST_FILE_VERSION };
+
+      await createManifestFile(tmpDir, rootManifest);
+      const pkg1Dir = join(tmpDir, "packages", "pkg1");
+      const pkg2Dir = join(tmpDir, "packages", "pkg2");
+      await createManifestFile(pkg1Dir, child1Manifest, "manifest.json");
+      await createManifestFile(pkg2Dir, child2Manifest, "manifest.json");
+
+      const result = await resolver.resolveWorkspace({ startDir: tmpDir });
+
+      expect(result).not.toBeNull();
+      expect(result?.rootPath).toBe(tmpDir);
+      expect(result?.ancestor.manifest.slug).toBe("root");
+      expect(result?.children).toHaveLength(2);
+
+      const childPaths = result?.children.map((c) => c.path).sort();
+      expect(childPaths).toEqual([
+        join("packages", "pkg1", "manifest.json"),
+        join("packages", "pkg2", "manifest.json"),
+      ]);
+
+      const childSlugs = result?.children.map((c) => c.manifest.slug).sort();
+      expect(childSlugs).toEqual(["child1", "child2"]);
+    });
+
+    it("should resolve correctly when startDir is a subdirectory", async () => {
+      const rootManifest = {
+        slug: "root",
+        manifestVersion: CURRENT_MANIFEST_FILE_VERSION,
+        workspaces: ["packages/pkg/manifest.json"],
+      };
+      const childManifest = { slug: "child", manifestVersion: CURRENT_MANIFEST_FILE_VERSION };
+
+      const subDir = join(tmpDir, "some", "subdir");
+      await createManifestFile(tmpDir, rootManifest);
+      const pkgDir = join(tmpDir, "packages", "pkg");
+      await createManifestFile(pkgDir, childManifest, "manifest.json");
+
+      await mkdir(subDir, { recursive: true });
+
+      const result = await resolver.resolveWorkspace({ startDir: subDir });
+
+      expect(result).not.toBeNull();
+      expect(result?.rootPath).toBe(tmpDir);
+      expect(result?.ancestor.manifest.slug).toBe("root");
+      expect(result?.ancestor.path).toBe(DEFAULT_MANIFEST_FILENAME);
+      expect(result?.children).toHaveLength(1);
+      expect(result?.children[0].manifest.slug).toBe("child");
+      expect(result?.children[0].path).toBe(join("packages", "pkg", "manifest.json"));
+    });
+
+    it("should use custom filename if provided", async () => {
+      const customFilename = "project.json";
+      const rootManifest = { slug: "root-custom", manifestVersion: CURRENT_MANIFEST_FILE_VERSION };
+      await createManifestFile(tmpDir, rootManifest, customFilename);
+
+      const result = await resolver.resolveWorkspace({
+        startDir: tmpDir,
+        filename: customFilename,
+      });
+
+      expect(result).not.toBeNull();
+      expect(result?.rootPath).toBe(tmpDir);
+      expect(result?.ancestor.path).toBe(customFilename);
+      expect(result?.ancestor.manifest.slug).toBe("root-custom");
+      expect(result?.children).toEqual([]);
+    });
+
+    it("should handle direct file references that don't exist", async () => {
+      const rootManifest = {
+        slug: "root",
+        manifestVersion: CURRENT_MANIFEST_FILE_VERSION,
+        workspaces: ["packages/exists/manifest.json", "packages/nonexistent/custom.json"],
+      };
+
+      const existingManifest = { slug: "exists", manifestVersion: CURRENT_MANIFEST_FILE_VERSION };
+
+      await createManifestFile(tmpDir, rootManifest);
+      await createManifestFile(
+        join(tmpDir, "packages", "exists"),
+        existingManifest,
+        "manifest.json",
+      );
+
+      const result = await resolver.resolveWorkspace({ startDir: tmpDir });
+
+      expect(result).not.toBeNull();
+      expect(result?.rootPath).toBe(tmpDir);
+      expect(result?.ancestor.manifest.slug).toBe("root");
+      expect(result?.children).toHaveLength(1);
+      expect(result?.children[0].path).toBe(join("packages", "exists", "manifest.json"));
+      expect(result?.children[0].manifest.slug).toBe("exists");
+    });
+  });
+
+  // Add tests for getManifestInfo and workspaceToSyncManifest later if needed
+});

--- a/packages/contract-tools/manifest/manifest.fs.test.ts
+++ b/packages/contract-tools/manifest/manifest.fs.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, beforeAll, afterAll } from "bun:test";
-import { initManifest, readManifest, writeManifest } from "./manifest.fs";
+import { initManifest, readManifestOrGetEmpty, writeManifest } from "./manifest.fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -18,7 +18,7 @@ afterAll(async () => {
 });
 
 test("writeManifest - overrides manifest", async () => {
-  const manifest = await readManifest(manifestPath);
+  const manifest = await readManifestOrGetEmpty(manifestPath);
 
   expect(manifest.slug).toBe("test-manifest");
 
@@ -38,7 +38,7 @@ test("writeManifest - overrides manifest", async () => {
 
   await writeManifest(manifest, manifestPath);
 
-  const manifest2 = await readManifest(manifestPath);
+  const manifest2 = await readManifestOrGetEmpty(manifestPath);
 
   expect(manifest2.connections).toEqual(manifest.connections);
 });

--- a/packages/contract/logger/logger.ts
+++ b/packages/contract/logger/logger.ts
@@ -63,8 +63,12 @@ export abstract class ILogger {
 
   logErrorInstance(error: unknown): void {
     if (error instanceof Error) {
-      for (const stack of error.stack?.split("\n") ?? []) {
-        this.error(stack);
+      const stack = error.stack?.split("\n") ?? [];
+
+      this.error("Error: " + error.message + (!stack.length ? " (no stack trace)" : ""));
+
+      for (const line of stack) {
+        this.error(line);
       }
 
       if (error.cause instanceof Error) {

--- a/packages/contract/workspace/workspace.ts
+++ b/packages/contract/workspace/workspace.ts
@@ -1,11 +1,14 @@
-import type { IManifestWorkspaceResolver, Workspace } from "@rejot-dev/contract-tools/manifest";
+import type {
+  IManifestWorkspaceResolver,
+  WorkspaceDefinition,
+} from "@rejot-dev/contract-tools/manifest";
 import type { SyncManifest } from "@rejot-dev/contract/sync-manifest";
 import { ReJotError } from "@rejot-dev/contract/error";
 
 export interface IWorkspaceService {
   resolveWorkspace(
     projectDir: string,
-  ): Promise<{ workspace: Workspace; syncManifest: SyncManifest }>;
+  ): Promise<{ workspace: WorkspaceDefinition; syncManifest: SyncManifest }>;
 }
 
 export class WorkspaceInitializationError extends ReJotError {
@@ -23,7 +26,7 @@ export class WorkspaceService implements IWorkspaceService {
 
   async resolveWorkspace(
     projectDir: string,
-  ): Promise<{ workspace: Workspace; syncManifest: SyncManifest }> {
+  ): Promise<{ workspace: WorkspaceDefinition; syncManifest: SyncManifest }> {
     const workspace = await this.#workspaceResolver.resolveWorkspace({
       startDir: projectDir,
     });


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Improved the separation between workspace and manifest concepts in MCP by introducing clear APIs and tools for workspace management.

- **New Features**
  - Added `rejot_workspace_init` and `rejot_workspace_info` tools for initializing and inspecting workspaces.
  - Updated manifest initialization to support sub-manifests and ensure workspace manifests track their children.
  - Enhanced test coverage for workspace resolution and manifest handling.

- **Refactors**
  - Renamed variables and interfaces to clarify the difference between workspace and manifest.
  - Updated internal APIs and file structure to reflect the new separation.
  - Simplified manifest reading and writing logic.

<!-- End of auto-generated description by mrge. -->

