### PR TITLE
Contract: make data store config connection type specific

### DIFF
--- a/apps/rejot-cli/src/commands/manifest-datastore/manifest-datastore-add.command.ts
+++ b/apps/rejot-cli/src/commands/manifest-datastore/manifest-datastore-add.command.ts
@@ -1,6 +1,9 @@
-import { Command } from "@oclif/core";
 import path from "node:path";
+
 import { readManifest, writeManifest } from "@rejot-dev/contract-tools/manifest";
+
+import { Command } from "@oclif/core";
+
 import {
   manifestFlags,
   validateConnection,
@@ -25,6 +28,14 @@ export class ManifestDataStoreAddCommand extends Command {
       this.error("--connection is required for add");
     }
 
+    if (!flags.publication) {
+      this.error("--publication is required for add");
+    }
+
+    if (!flags.slot) {
+      this.error("--slot is required for add");
+    }
+
     await validateConnection(manifestPath, flags.connection);
     await validateUniqueConnection(manifestPath, flags.connection);
 
@@ -32,8 +43,11 @@ export class ManifestDataStoreAddCommand extends Command {
     manifest.dataStores = manifest.dataStores ?? [];
     manifest.dataStores.push({
       connectionSlug: flags.connection,
-      publicationName: flags.publication,
-      slotName: flags.slot,
+      config: {
+        connectionType: "postgres",
+        publicationName: flags.publication,
+        slotName: flags.slot,
+      },
     });
 
     await writeManifest(manifest, manifestPath);

--- a/apps/rejot-cli/src/commands/manifest-datastore/manifest-datastore-config.ts
+++ b/apps/rejot-cli/src/commands/manifest-datastore/manifest-datastore-config.ts
@@ -1,4 +1,5 @@
 import { readManifest } from "@rejot-dev/contract-tools/manifest";
+
 import { Flags } from "@oclif/core";
 
 export const manifestFlags = {

--- a/apps/rejot-cli/src/commands/manifest-datastore/manifest-datastore-list.command.ts
+++ b/apps/rejot-cli/src/commands/manifest-datastore/manifest-datastore-list.command.ts
@@ -1,6 +1,9 @@
-import { Command } from "@oclif/core";
 import path from "node:path";
-import { readManifest } from "@rejot-dev/contract-tools/manifest";
+
+import { ManifestPrinter, readManifest } from "@rejot-dev/contract-tools/manifest";
+
+import { Command } from "@oclif/core";
+
 import { manifestFlags } from "./manifest-datastore-config";
 
 export class ManifestDataStoreListCommand extends Command {
@@ -16,15 +19,6 @@ export class ManifestDataStoreListCommand extends Command {
     const manifestPath = path.resolve(flags.manifest);
     const manifest = await readManifest(manifestPath);
 
-    if ((manifest.dataStores ?? []).length === 0) {
-      this.log("No data stores found in manifest");
-      return;
-    }
-
-    this.log("Data Stores:");
-    for (const ds of manifest.dataStores ?? []) {
-      this.log(`  - Connection: ${ds.connectionSlug}`);
-      this.log(`    Publication: ${ds.publicationName}`);
-    }
+    this.log(ManifestPrinter.printDataStores(manifest).join("\n"));
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "eslint-plugin-react": "^7.37.4",
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "eslint-plugin-tailwindcss": "^3.18.0",
+        "eslint-plugin-unicorn": "^58.0.0",
         "lefthook": "^1.10.10",
         "prettier": "3.5.1",
         "prettier-plugin-embed": "^0.4.15",
@@ -1033,6 +1034,8 @@
 
     "@types/node": ["@types/node@22.13.4", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg=="],
 
+    "@types/normalize-package-data": ["@types/normalize-package-data@2.4.4", "", {}, "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="],
+
     "@types/pg": ["@types/pg@8.11.11", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^4.0.1" } }, "sha512-kGT1qKM8wJQ5qlawUrEkXgvMSXoV213KfMGXcwfDwUIfUHXqXYXOfS1nE1LINRJVVVx5wCm70XnFlMHaIcQAfw=="],
 
     "@types/pg-pool": ["@types/pg-pool@2.0.6", "", { "dependencies": { "@types/pg": "*" } }, "sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ=="],
@@ -1209,6 +1212,8 @@
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
+    "builtin-modules": ["builtin-modules@5.0.0", "", {}, "sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg=="],
+
     "bun-types": ["bun-types@1.2.4", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-nDPymR207ZZEoWD4AavvEaa/KZe/qlrbMSchqpQwovPZCKc7pwMoENjEtHgMKaAjJhy+x6vfqSBA1QU3bJgs0Q=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
@@ -1253,13 +1258,15 @@
 
     "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
-    "ci-info": ["ci-info@3.9.0", "", {}, "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="],
+    "ci-info": ["ci-info@4.2.0", "", {}, "sha512-cYY9mypksY8NRqgDB1XD1RiJL338v/551niynFTGkZOO2LHuB2OmOYxDIe/ttN9AHwrqdum1360G3ald0W9kCg=="],
 
     "cjs-module-lexer": ["cjs-module-lexer@1.4.3", "", {}, "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q=="],
 
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
 
     "classcat": ["classcat@5.0.5", "", {}, "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w=="],
+
+    "clean-regexp": ["clean-regexp@1.0.0", "", { "dependencies": { "escape-string-regexp": "^1.0.5" } }, "sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw=="],
 
     "clean-stack": ["clean-stack@3.0.1", "", { "dependencies": { "escape-string-regexp": "4.0.0" } }, "sha512-lR9wNiMRcVQjSB3a7xXGLuz4cr4wJuuXlaAEbRutGowQTmlp7R72/DOgN21e8jdwblMWl9UOJMJXarX94pzKdg=="],
 
@@ -1302,6 +1309,8 @@
     "cookie": ["cookie@1.0.2", "", {}, "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA=="],
 
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "core-js-compat": ["core-js-compat@3.41.0", "", { "dependencies": { "browserslist": "^4.24.4" } }, "sha512-RFsU9LySVue9RTwdDVX/T0e2Y6jRYWXERKElIjpuEOEnxaXffI0X7RUwVzfYLfzuLXSNJDYoRYUAmRUcyln20A=="],
 
     "cors": ["cors@2.8.5", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g=="],
 
@@ -1463,6 +1472,8 @@
 
     "eslint-plugin-tailwindcss": ["eslint-plugin-tailwindcss@3.18.0", "", { "dependencies": { "fast-glob": "^3.2.5", "postcss": "^8.4.4" }, "peerDependencies": { "tailwindcss": "^3.4.0" } }, "sha512-PQDU4ZMzFH0eb2DrfHPpbgo87Zgg2EXSMOj1NSfzdZm+aJzpuwGerfowMIaVehSREEa0idbf/eoNYAOHSJoDAQ=="],
 
+    "eslint-plugin-unicorn": ["eslint-plugin-unicorn@58.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.25.9", "@eslint-community/eslint-utils": "^4.5.1", "@eslint/plugin-kit": "^0.2.7", "ci-info": "^4.2.0", "clean-regexp": "^1.0.0", "core-js-compat": "^3.41.0", "esquery": "^1.6.0", "globals": "^16.0.0", "indent-string": "^5.0.0", "is-builtin-module": "^5.0.0", "jsesc": "^3.1.0", "pluralize": "^8.0.0", "read-package-up": "^11.0.0", "regexp-tree": "^0.1.27", "regjsparser": "^0.12.0", "semver": "^7.7.1", "strip-indent": "^4.0.0" }, "peerDependencies": { "eslint": ">=9.22.0" } }, "sha512-fc3iaxCm9chBWOHPVjn+Czb/wHS0D2Mko7wkOdobqo9R2bbFObc4LyZaLTNy0mhZOP84nKkLhTUQxlLOZ7EjKw=="],
+
     "eslint-scope": ["eslint-scope@8.2.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A=="],
 
     "eslint-visitor-keys": ["eslint-visitor-keys@4.2.0", "", {}, "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw=="],
@@ -1607,7 +1618,7 @@
 
     "glob-to-regexp": ["glob-to-regexp@0.4.1", "", {}, "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="],
 
-    "globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
+    "globals": ["globals@16.0.0", "", {}, "sha512-iInW14XItCXET01CQFqudPOWP2jYMl7T+QRQT+UNcR/iQncN/F0UNpgd76iFkBPgNQb4+X3LV9tLJYzwh+Gl3A=="],
 
     "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
 
@@ -1671,7 +1682,9 @@
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
-    "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
+    "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
+
+    "index-to-position": ["index-to-position@1.1.0", "", {}, "sha512-XPdx9Dq4t9Qk1mTMbWONJqU7boCoumEH7fRET37HX5+khDUl3J2W6PdALxhILYlIYx2amlwYcRPp28p0tSiojg=="],
 
     "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
 
@@ -1694,6 +1707,8 @@
     "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
 
     "is-boolean-object": ["is-boolean-object@1.2.2", "", { "dependencies": { "call-bound": "^1.0.3", "has-tostringtag": "^1.0.2" } }, "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A=="],
+
+    "is-builtin-module": ["is-builtin-module@5.0.0", "", { "dependencies": { "builtin-modules": "^5.0.0" } }, "sha512-f4RqJKBUe5rQkJ2eJEJBXSticB3hGbN9j0yxxMQFqIW89Jp9WYFtzfTcRlstDKVUTRzSOTLKRfO9vIztenwtxA=="],
 
     "is-callable": ["is-callable@1.2.7", "", {}, "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="],
 
@@ -1943,6 +1958,8 @@
 
     "mimic-response": ["mimic-response@4.0.0", "", {}, "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg=="],
 
+    "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
+
     "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
@@ -2043,7 +2060,7 @@
 
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
-    "parse-json": ["parse-json@4.0.0", "", { "dependencies": { "error-ex": "^1.3.1", "json-parse-better-errors": "^1.0.1" } }, "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw=="],
+    "parse-json": ["parse-json@8.3.0", "", { "dependencies": { "@babel/code-frame": "^7.26.2", "index-to-position": "^1.1.0", "type-fest": "^4.39.1" } }, "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ=="],
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
@@ -2102,6 +2119,8 @@
     "pkce-challenge": ["pkce-challenge@5.0.0", "", {}, "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ=="],
 
     "pkg-dir": ["pkg-dir@4.2.0", "", { "dependencies": { "find-up": "^4.0.0" } }, "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ=="],
+
+    "pluralize": ["pluralize@8.0.0", "", {}, "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
@@ -2203,6 +2222,10 @@
 
     "read-cache": ["read-cache@1.0.0", "", { "dependencies": { "pify": "^2.3.0" } }, "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA=="],
 
+    "read-package-up": ["read-package-up@11.0.0", "", { "dependencies": { "find-up-simple": "^1.0.0", "read-pkg": "^9.0.0", "type-fest": "^4.6.0" } }, "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ=="],
+
+    "read-pkg": ["read-pkg@9.0.1", "", { "dependencies": { "@types/normalize-package-data": "^2.4.3", "normalize-package-data": "^6.0.0", "parse-json": "^8.0.0", "type-fest": "^4.6.0", "unicorn-magic": "^0.1.0" } }, "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA=="],
+
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
@@ -2211,9 +2234,13 @@
 
     "regenerator-runtime": ["regenerator-runtime@0.14.1", "", {}, "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="],
 
+    "regexp-tree": ["regexp-tree@0.1.27", "", { "bin": { "regexp-tree": "bin/regexp-tree" } }, "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA=="],
+
     "regexp.prototype.flags": ["regexp.prototype.flags@1.5.4", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-errors": "^1.3.0", "get-proto": "^1.0.1", "gopd": "^1.2.0", "set-function-name": "^2.0.2" } }, "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA=="],
 
     "registry-auth-token": ["registry-auth-token@5.1.0", "", { "dependencies": { "@pnpm/npm-conf": "^2.1.0" } }, "sha512-GdekYuwLXLxMuFTwAPg5UKGLW/UXzQrZvH/Zj791BQif5T05T0RsaLfHc9q3ZOKi7n+BoprPD9mJ0O0k4xzUlw=="],
+
+    "regjsparser": ["regjsparser@0.12.0", "", { "dependencies": { "jsesc": "~3.0.2" }, "bin": { "regjsparser": "bin/parser" } }, "sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
@@ -2379,6 +2406,8 @@
 
     "strip-final-newline": ["strip-final-newline@2.0.0", "", {}, "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="],
 
+    "strip-indent": ["strip-indent@4.0.0", "", { "dependencies": { "min-indent": "^1.0.1" } }, "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA=="],
+
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
     "strnum": ["strnum@1.1.2", "", {}, "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA=="],
@@ -2480,6 +2509,8 @@
     "undefsafe": ["undefsafe@2.0.5", "", {}, "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA=="],
 
     "undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
+
+    "unicorn-magic": ["unicorn-magic@0.1.0", "", {}, "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ=="],
 
     "universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 
@@ -2607,6 +2638,8 @@
 
     "@eslint/eslintrc/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
+    "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
+
     "@eslint/plugin-kit/@eslint/core": ["@eslint/core@0.10.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-gFHJ+xBOo4G3WRlR1e/3G8A6/KZAH6zcE/hkLRCZTi/B9avAG365QhFA8uOGzTMqgTghpn7/fSnscW++dpMSAw=="],
 
     "@humanfs/node/@humanwhocodes/retry": ["@humanwhocodes/retry@0.3.1", "", {}, "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA=="],
@@ -2663,6 +2696,8 @@
 
     "@istanbuljs/load-nyc-config/resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
 
+    "@jest/core/ci-info": ["ci-info@3.9.0", "", {}, "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="],
+
     "@jest/reporters/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "@modelcontextprotocol/inspector-client/@radix-ui/react-slot": ["@radix-ui/react-slot@1.1.2", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ=="],
@@ -2674,6 +2709,8 @@
     "@modelcontextprotocol/inspector-client/tailwind-merge": ["tailwind-merge@2.6.0", "", {}, "sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA=="],
 
     "@modelcontextprotocol/inspector-server/express": ["express@4.21.2", "", { "dependencies": { "accepts": "~1.3.8", "array-flatten": "1.1.1", "body-parser": "1.20.3", "content-disposition": "0.5.4", "content-type": "~1.0.4", "cookie": "0.7.1", "cookie-signature": "1.0.6", "debug": "2.6.9", "depd": "2.0.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "finalhandler": "1.3.1", "fresh": "0.5.2", "http-errors": "2.0.0", "merge-descriptors": "1.0.3", "methods": "~1.1.2", "on-finished": "2.4.1", "parseurl": "~1.3.3", "path-to-regexp": "0.1.12", "proxy-addr": "~2.0.7", "qs": "6.13.0", "range-parser": "~1.2.1", "safe-buffer": "5.2.1", "send": "0.19.0", "serve-static": "1.16.2", "setprototypeof": "1.2.0", "statuses": "2.0.1", "type-is": "~1.6.18", "utils-merge": "1.0.1", "vary": "~1.1.2" } }, "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA=="],
+
+    "@oclif/core/indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
     "@oclif/core/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
@@ -2777,6 +2814,8 @@
 
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "clean-regexp/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
+
     "decompress-response/mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
 
     "dot-case/tslib": ["tslib@2.4.1", "", {}, "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="],
@@ -2784,6 +2823,12 @@
     "drizzle-kit/esbuild": ["esbuild@0.19.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.19.12", "@esbuild/android-arm": "0.19.12", "@esbuild/android-arm64": "0.19.12", "@esbuild/android-x64": "0.19.12", "@esbuild/darwin-arm64": "0.19.12", "@esbuild/darwin-x64": "0.19.12", "@esbuild/freebsd-arm64": "0.19.12", "@esbuild/freebsd-x64": "0.19.12", "@esbuild/linux-arm": "0.19.12", "@esbuild/linux-arm64": "0.19.12", "@esbuild/linux-ia32": "0.19.12", "@esbuild/linux-loong64": "0.19.12", "@esbuild/linux-mips64el": "0.19.12", "@esbuild/linux-ppc64": "0.19.12", "@esbuild/linux-riscv64": "0.19.12", "@esbuild/linux-s390x": "0.19.12", "@esbuild/linux-x64": "0.19.12", "@esbuild/netbsd-x64": "0.19.12", "@esbuild/openbsd-x64": "0.19.12", "@esbuild/sunos-x64": "0.19.12", "@esbuild/win32-arm64": "0.19.12", "@esbuild/win32-ia32": "0.19.12", "@esbuild/win32-x64": "0.19.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg=="],
 
     "eslint/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
+
+    "eslint-plugin-unicorn/@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.6.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-KTsJMmobmbrFLe3LDh0PC2FXpcSYJt/MLjlkh/9LEnmKYLSYmT/0EW9JWANjeoemiuZrmogti0tW5Ch+qNUYDw=="],
+
+    "eslint-plugin-unicorn/@eslint/plugin-kit": ["@eslint/plugin-kit@0.2.8", "", { "dependencies": { "@eslint/core": "^0.13.0", "levn": "^0.4.1" } }, "sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA=="],
+
+    "eslint-plugin-unicorn/semver": ["semver@7.7.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="],
 
     "execa/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
@@ -2801,9 +2846,13 @@
 
     "hosted-git-info/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
+    "http-call/parse-json": ["parse-json@4.0.0", "", { "dependencies": { "error-ex": "^1.3.1", "json-parse-better-errors": "^1.0.1" } }, "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw=="],
+
     "istanbul-lib-instrument/semver": ["semver@7.7.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="],
 
     "istanbul-lib-report/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "jest-config/ci-info": ["ci-info@3.9.0", "", {}, "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="],
 
     "jest-config/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
@@ -2818,6 +2867,8 @@
     "jest-runtime/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "jest-snapshot/semver": ["semver@7.7.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="],
+
+    "jest-util/ci-info": ["ci-info@3.9.0", "", {}, "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="],
 
     "lower-case/tslib": ["tslib@2.4.1", "", {}, "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="],
 
@@ -2836,6 +2887,8 @@
     "normalize-package-data/semver": ["semver@7.7.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="],
 
     "oclif/semver": ["semver@7.7.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="],
+
+    "parse-json/type-fest": ["type-fest@4.40.0", "", {}, "sha512-ABHZ2/tS2JkvH1PEjxFDTUWC8dB5OsIGZP4IFLhR293GqT5Y5qB1WwL2kMPYhQW9DVgVD8Hd7I8gjwPIf5GFkw=="],
 
     "pg/pg-protocol": ["pg-protocol@1.8.0", "", {}, "sha512-jvuYlEkL03NRvOoyoRktBK7+qU5kOvlAwvmrH8sr3wbLrOdVWsRxQfz8mMy9sZFsqJ1hEWNfdWKI4SAmoL+j7g=="],
 
@@ -2858,6 +2911,8 @@
     "react-remove-scroll-bar/tslib": ["tslib@2.4.1", "", {}, "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="],
 
     "react-style-singleton/tslib": ["tslib@2.4.1", "", {}, "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="],
+
+    "regjsparser/jsesc": ["jsesc@3.0.2", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g=="],
 
     "require-in-the-middle/resolve": ["resolve@1.22.10", "", { "dependencies": { "is-core-module": "^2.16.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w=="],
 
@@ -3152,6 +3207,10 @@
     "drizzle-kit/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.19.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ=="],
 
     "drizzle-kit/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.19.12", "", { "os": "win32", "cpu": "x64" }, "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA=="],
+
+    "eslint-plugin-unicorn/@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "eslint-plugin-unicorn/@eslint/plugin-kit/@eslint/core": ["@eslint/core@0.13.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw=="],
 
     "eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,23 +1,38 @@
 // @ts-check
 
-import eslint from "@eslint/js";
 import eslintConfigPrettier from "eslint-config-prettier";
 import eslintPluginReact from "eslint-plugin-react";
 import eslintPluginSimpleImportSort from "eslint-plugin-simple-import-sort";
 import eslintPluginTailwindcss from "eslint-plugin-tailwindcss";
+import eslintPluginUnicorn from "eslint-plugin-unicorn";
 import tseslint from "typescript-eslint";
+
+import eslint from "@eslint/js";
 
 const frontendAppFiles = ["apps/controller-spa/**/*.{ts,tsx}"];
 
+// TODO: We might start using this at a later point. https://github.com/sindresorhus/eslint-plugin-unicorn/tree/main
+const _unicornFixableRules = Object.fromEntries(
+  Object.entries(eslintPluginUnicorn.rules ?? {}).map(([id, rule]) => [
+    `unicorn/${id}`,
+    rule.meta?.fixable ? "error" : "off",
+  ]),
+);
+
 export default tseslint.config(
+  {
+    ignores: ["**/node_modules/**", "**/dist/**"],
+  },
   eslint.configs.recommended,
   tseslint.configs.recommended,
   eslintConfigPrettier,
   {
     plugins: {
       "simple-import-sort": eslintPluginSimpleImportSort,
+      unicorn: eslintPluginUnicorn,
     },
     rules: {
+      // ...unicornFixableRules,
       "@typescript-eslint/no-unused-vars": [
         "error",
         {
@@ -38,18 +53,23 @@ export default tseslint.config(
         {
           groups: [
             // Side effect imports.
-            ["^\\u0000"],
+            [String.raw`^\u0000`],
+            // Stuff related to test.
+            ["test$"],
             // Node.js builtins prefixed with `node:`.
-            ["^node:"],
-            // Packages.
-            // Things that start with a letter (or digit or underscore), or `@` followed by a letter.
-            ["^@?\\w"],
+            ["^(node|bun):"],
+            // Packages. Things that start with a letter (or digit or underscore).
+            [String.raw`^\w`],
+            // Packages with a leading `@rejot-dev`
+            ["^@rejot-dev"],
+            // Packages with a leading `@`
+            ["^@"],
             // Absolute imports and other imports such as Vue-style `@/foo`.
             // Anything not matched in another group.
             ["^"],
             // Relative imports.
             // Anything that starts with a dot.
-            ["^\\."],
+            [String.raw`^\\.`],
           ],
         },
       ],

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint-plugin-react": "^7.37.4",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-tailwindcss": "^3.18.0",
+    "eslint-plugin-unicorn": "^58.0.0",
     "lefthook": "^1.10.10",
     "prettier": "3.5.1",
     "prettier-plugin-embed": "^0.4.15",

--- a/packages/adapter-postgres/src/adapter/index.ts
+++ b/packages/adapter-postgres/src/adapter/index.ts
@@ -1,14 +1,10 @@
-export { PostgresConnectionAdapter } from "./pg-connection-adapter.ts";
 export type { PostgresConnection } from "./pg-connection-adapter.ts";
-
-export { PostgresPublicSchemaTransformationAdapter } from "./pg-public-schema-transformation-adapter.ts";
+export { PostgresConnectionAdapter } from "./pg-connection-adapter.ts";
 export { PostgresConsumerSchemaTransformationAdapter } from "./pg-consumer-schema-transformation-adapter.ts";
-
-export {
-  createPostgresPublicSchemaTransformation,
-  createPostgresConsumerSchemaTransformation,
-} from "./pg-transformations.ts";
-
 export { PostgresConsumerSchemaValidationAdapter } from "./pg-consumer-schema-validation-adapter.ts";
-
 export { PostgresIntrospectionAdapter } from "./pg-introspection-adapter.ts";
+export { PostgresPublicSchemaTransformationAdapter } from "./pg-public-schema-transformation-adapter.ts";
+export {
+  createPostgresConsumerSchemaTransformation,
+  createPostgresPublicSchemaTransformation,
+} from "./pg-transformations.ts";

--- a/packages/adapter-postgres/src/adapter/pg-connection-adapter.ts
+++ b/packages/adapter-postgres/src/adapter/pg-connection-adapter.ts
@@ -1,13 +1,14 @@
 import { z } from "zod";
 
-import type { IConnectionAdapter, CreateSourceOptions } from "@rejot-dev/contract/adapter";
-import type { PostgresConnectionSchema } from "../postgres-schemas.ts";
-import { PostgresSource } from "../postgres-source.ts";
-import { DEFAULT_PUBLICATION_NAME, DEFAULT_SLOT_NAME } from "../postgres-consts.ts";
-import { PostgresEventStore } from "../event-store/postgres-event-store.ts";
-import { PostgresClient } from "../util/postgres-client.ts";
-import { PostgresSink } from "../postgres-sink.ts";
+import type { IConnectionAdapter } from "@rejot-dev/contract/adapter";
 import type { IConnection } from "@rejot-dev/contract/sync";
+
+import { PostgresEventStore } from "../event-store/postgres-event-store.ts";
+import { DEFAULT_PUBLICATION_NAME, DEFAULT_SLOT_NAME } from "../postgres-consts.ts";
+import type { PostgresConnectionSchema, PostgresDataStoreSchema } from "../postgres-schemas.ts";
+import { PostgresSink } from "../postgres-sink.ts";
+import { PostgresSource } from "../postgres-source.ts";
+import { PostgresClient } from "../util/postgres-client.ts";
 
 export interface PostgresConnection extends IConnection<z.infer<typeof PostgresConnectionSchema>> {
   client: PostgresClient;
@@ -17,6 +18,7 @@ export class PostgresConnectionAdapter
   implements
     IConnectionAdapter<
       z.infer<typeof PostgresConnectionSchema>,
+      z.infer<typeof PostgresDataStoreSchema>,
       PostgresSource,
       PostgresSink,
       PostgresEventStore
@@ -31,15 +33,15 @@ export class PostgresConnectionAdapter
   createSource(
     connectionSlug: string,
     connection: z.infer<typeof PostgresConnectionSchema>,
-    options?: CreateSourceOptions,
+    options: z.infer<typeof PostgresDataStoreSchema>,
   ): PostgresSource {
     return new PostgresSource({
       client: this.getOrCreateConnection(connectionSlug, connection).client,
       publicSchemaSql: "",
       options: {
         createPublication: true,
-        publicationName: options?.publicationName ?? DEFAULT_PUBLICATION_NAME,
-        slotName: options?.slotName ?? DEFAULT_SLOT_NAME,
+        publicationName: options.publicationName ?? DEFAULT_PUBLICATION_NAME,
+        slotName: options.slotName ?? DEFAULT_SLOT_NAME,
       },
     });
   }

--- a/packages/adapter-postgres/src/adapter/pg-introspection-adapter.ts
+++ b/packages/adapter-postgres/src/adapter/pg-introspection-adapter.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
-import type { IIntrospectionAdapter, Table, Column } from "@rejot-dev/contract/adapter";
+
+import type { Column, IIntrospectionAdapter, Table } from "@rejot-dev/contract/adapter";
+
 import type { PostgresConnectionSchema } from "../postgres-schemas";
 import { PostgresConnectionAdapter } from "./pg-connection-adapter";
 

--- a/packages/adapter-postgres/src/postgres-schemas.ts
+++ b/packages/adapter-postgres/src/postgres-schemas.ts
@@ -20,3 +20,9 @@ export const PostgresConsumerSchemaTransformationSchema = z.object({
   sql: z.string(),
   whenOperation: z.enum(["insertOrUpdate", "delete"]).optional(),
 });
+
+export const PostgresDataStoreSchema = z.object({
+  connectionType: z.literal("postgres").describe("Postgres connection type."),
+  publicationName: z.string().describe("Name of the publication (for Postgres)."),
+  slotName: z.string().describe("Name of the replication slot (for Postgres)."),
+});

--- a/packages/adapter-postgres/src/postgres-source.ts
+++ b/packages/adapter-postgres/src/postgres-source.ts
@@ -1,14 +1,14 @@
-import { PostgresClient } from "./util/postgres-client";
 import { getLogger } from "@rejot-dev/contract/logger";
 import type {
   IDataSource,
+  TableOperation,
   Transaction,
   TransformedOperation,
-  TableOperation,
 } from "@rejot-dev/contract/sync";
-import { DEFAULT_SLOT_NAME } from "./postgres-consts";
+
+import { DEFAULT_PUBLICATION_NAME, DEFAULT_SLOT_NAME } from "./postgres-consts";
 import { PostgresReplicationListener } from "./postgres-replication-listener";
-import { DEFAULT_PUBLICATION_NAME } from "./postgres-consts";
+import { PostgresClient } from "./util/postgres-client";
 import { isPostgresError, PG_DUPLICATE_OBJECT } from "./util/postgres-error-codes";
 
 const log = getLogger("pg-source");

--- a/packages/contract-tools/manifest/manifest-printer.ts
+++ b/packages/contract-tools/manifest/manifest-printer.ts
@@ -4,6 +4,7 @@ import {
   ConnectionSchema,
   type PublicSchemaSchema,
   type ConsumerSchemaSchema,
+  type DataStoreConfigSchema,
 } from "@rejot-dev/contract/manifest";
 import type { SyncManifest } from "@rejot-dev/contract/sync-manifest";
 import type { WorkspaceDefinition } from "./manifest-workspace-resolver";
@@ -82,7 +83,7 @@ export class ManifestPrinter {
     return output;
   }
 
-  private static printDataStores(manifest: Manifest): string[] {
+  static printDataStores(manifest: Manifest): string[] {
     const output: string[] = ["Data Stores (Replication Sources):"];
 
     if ((manifest.dataStores ?? []).length === 0) {
@@ -92,10 +93,19 @@ export class ManifestPrinter {
 
     for (const ds of manifest.dataStores ?? []) {
       output.push(`  - Connection: ${ds.connectionSlug}`);
-      output.push(`    Publication / slot: ${ds.publicationName ?? ""} / ${ds.slotName ?? ""}`);
+      output.push(this.printDataStoreConfig(ds.config));
     }
 
     return output;
+  }
+
+  private static printDataStoreConfig(config: z.infer<typeof DataStoreConfigSchema>): string {
+    switch (config.connectionType) {
+      case "postgres":
+        return `    Publication / slot: ${config.publicationName} / ${config.slotName}`;
+      case "in-memory":
+        return `    In-memory connection`;
+    }
   }
 
   private static printEventStores(manifest: Manifest): string[] {

--- a/packages/contract-tools/manifest/manifest.fs.ts
+++ b/packages/contract-tools/manifest/manifest.fs.ts
@@ -1,10 +1,12 @@
-import { SyncManifestSchema } from "@rejot-dev/contract/manifest";
-import { mkdir, open, readFile, writeFile } from "node:fs/promises";
 import { constants } from "node:fs";
+import { mkdir, open, readFile, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
+
 import { z } from "zod";
 
 import { getLogger } from "@rejot-dev/contract/logger";
+import { SyncManifestSchema } from "@rejot-dev/contract/manifest";
+
 import { mergeManifests } from "../../contract/manifest/manifest-helpers";
 
 const log = getLogger(import.meta.url);

--- a/packages/contract/adapter/adapter.ts
+++ b/packages/contract/adapter/adapter.ts
@@ -13,6 +13,7 @@ import {
   ConsumerSchemaTransformationSchema,
   PublicSchemaTransformationSchema,
   type ConsumerSchemaSchema,
+  type DataStoreConfigSchema,
   type PublicSchemaSchema,
 } from "../manifest/manifest.ts";
 import type { IEventStore, TransformedOperationWithSource } from "../event-store/event-store.ts";
@@ -49,6 +50,7 @@ export interface OperationTransformationPair<
 
 export interface IConnectionAdapter<
   TConnectionConfig extends z.infer<typeof ConnectionConfigSchema>,
+  TDataStoreConfig extends z.infer<typeof DataStoreConfigSchema>,
   TSource extends IDataSource,
   TSink extends IDataSink,
   TEventStore extends IEventStore,
@@ -58,7 +60,7 @@ export interface IConnectionAdapter<
   createSource(
     connectionSlug: string,
     connectionConfig: TConnectionConfig,
-    options?: CreateSourceOptions,
+    options: TDataStoreConfig,
   ): TSource;
   createSink(connectionSlug: string, connectionConfig: TConnectionConfig): TSink;
   createEventStore(connectionSlug: string, connectionConfig: TConnectionConfig): TEventStore;
@@ -71,6 +73,7 @@ export interface IConnectionAdapter<
 
 export type AnyIConnectionAdapter = IConnectionAdapter<
   z.infer<typeof ConnectionConfigSchema>,
+  z.infer<typeof DataStoreConfigSchema>,
   IDataSource,
   IDataSink,
   IEventStore

--- a/packages/contract/json-schema/json-schema.test.ts
+++ b/packages/contract/json-schema/json-schema.test.ts
@@ -1,9 +1,11 @@
 import { expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+
 import type { JsonSchema7Type } from "zod-to-json-schema";
-import { JsonSchemaSchema } from "./json-schema";
-import { extractSchemaKeys } from "./json-schema-utils";
 
 import type { JsonSchema } from "./json-schema";
+import { JsonSchemaSchema } from "./json-schema";
+import { extractSchemaKeys } from "./json-schema-utils";
 
 type JsonSchemaFromLib = JsonSchema7Type & {
   $schema?: string;
@@ -19,10 +21,8 @@ test("Type check", () => {
 });
 
 test("Parse schema", async () => {
-  const exampleSchema = await fetch("https://json.schemastore.org/github-action.json").then((res) =>
-    res.json(),
-  );
-  JsonSchemaSchema.strict().parse(exampleSchema);
+  const exampleSchema = await readFile(new URL("../schema.json", import.meta.url), "utf-8");
+  JsonSchemaSchema.strict().parse(JSON.parse(exampleSchema));
 });
 
 // Tests for extractSchemaKeys function

--- a/packages/contract/manifest/manifest-helpers.ts
+++ b/packages/contract/manifest/manifest-helpers.ts
@@ -46,40 +46,27 @@ export function getConnectionBySlugHelper(
 }
 
 export function getSourceDataStoresHelper(manifests: Manifest[]): SourceDataStore[] {
-  const dataStores = manifests
+  return manifests
     .flatMap((manifest) =>
       (manifest.dataStores ?? []).map((ds) => ({
         ...ds,
         sourceManifestSlug: manifest.slug,
       })),
     )
-    .filter(
-      (
-        ds,
-      ): ds is {
-        connectionSlug: string;
-        publicationName: string;
-        slotName: string;
-        sourceManifestSlug: string;
-        // TODO: Type predicate only checks for publicationName and slotName but asserts a type
-        //       that includes more properties
-      } => Boolean(ds.publicationName && ds.slotName),
-    );
-
-  return dataStores.map((ds) => {
-    const connection = getConnectionBySlugHelper(manifests, ds.connectionSlug);
-    if (!connection) {
-      // This error should ideally be caught during verification, but keep for safety
-      throw new Error(`Connection '${ds.connectionSlug}' not found in manifests`);
-    }
-    return {
-      ...ds,
-      connection: {
-        slug: connection.slug,
-        config: connection.config,
-      },
-    };
-  });
+    .map((ds) => {
+      const connection = getConnectionBySlugHelper(manifests, ds.connectionSlug);
+      if (!connection) {
+        // This error should ideally be caught during verification, but keep for safety
+        throw new Error(`Connection '${ds.connectionSlug}' not found in manifests`);
+      }
+      return {
+        ...ds,
+        connection: {
+          slug: connection.slug,
+          config: connection.config,
+        },
+      };
+    });
 }
 
 export function getDestinationDataStoresHelper(manifests: Manifest[]): DestinationDataStore[] {

--- a/packages/contract/manifest/manifest.ts
+++ b/packages/contract/manifest/manifest.ts
@@ -1,18 +1,31 @@
 import { z } from "zod";
+
+// TODO: It makes no sense for the contract package to depend on an adapter.
 import {
   PostgresConnectionSchema,
-  PostgresPublicSchemaTransformationSchema,
   PostgresConsumerSchemaTransformationSchema,
+  PostgresDataStoreSchema,
+  PostgresPublicSchemaTransformationSchema,
 } from "@rejot-dev/adapter-postgres/schemas";
+
 import { JsonSchemaSchema } from "../json-schema/json-schema.ts";
 
 export const InMemoryConnectionConfigSchema = z.object({
   connectionType: z.literal("in-memory"),
 });
 
+export const InMemoryDataStoreConfigSchema = z.object({
+  connectionType: z.literal("in-memory"),
+});
+
 export const ConnectionConfigSchema = z.discriminatedUnion("connectionType", [
   PostgresConnectionSchema,
   InMemoryConnectionConfigSchema,
+]);
+
+export const DataStoreConfigSchema = z.discriminatedUnion("connectionType", [
+  PostgresDataStoreSchema,
+  InMemoryDataStoreConfigSchema,
 ]);
 
 export const ConnectionSchema = z.object({
@@ -30,8 +43,7 @@ export const ConsumerSchemaTransformationSchema = z.discriminatedUnion("transfor
 
 export const DataStoreSchema = z.object({
   connectionSlug: z.string().describe("Slug of the connection to use for this data store."),
-  publicationName: z.string().describe("Name of the publication (for Postgres).").optional(),
-  slotName: z.string().describe("Name of the replication slot (for Postgres).").optional(),
+  config: DataStoreConfigSchema.describe("Configuration details specific to the data store type."),
 });
 
 export const EventStoreSchema = z.object({
@@ -116,4 +128,4 @@ export const SyncManifestSchema = z.object({
   workspaces: z.array(z.string()).optional(),
 });
 
-export { verifyManifests, type ManifestError, type VerificationResult } from "./verify-manifest";
+export { type ManifestError, type VerificationResult, verifyManifests } from "./verify-manifest";

--- a/packages/contract/manifest/sync-manifest.ts
+++ b/packages/contract/manifest/sync-manifest.ts
@@ -1,30 +1,33 @@
 import { z } from "zod";
+
+import type { TransformedOperationWithSource } from "@rejot-dev/contract/event-store";
+import { getLogger } from "@rejot-dev/contract/logger";
+
 import {
-  SyncManifestSchema,
-  ConsumerSchemaSchema,
   type ConnectionConfigSchema,
+  ConsumerSchemaSchema,
+  type DataStoreConfigSchema,
   type PublicSchemaSchema,
+  SyncManifestSchema,
 } from "./manifest";
 import {
-  verifyManifests,
-  type ManifestError,
-  type ExternalPublicSchemaReference,
-  type VerificationResult,
-} from "./verify-manifest";
-import { getLogger } from "@rejot-dev/contract/logger";
-import type { TransformedOperationWithSource } from "@rejot-dev/contract/event-store";
-import {
-  getConnectionsHelper,
-  getDataStoresHelper,
-  getEventStoresHelper,
   getConnectionBySlugHelper,
-  getSourceDataStoresHelper,
-  getDestinationDataStoresHelper,
-  getExternalConsumerSchemasHelper,
+  getConnectionsHelper,
   getConsumerSchemasForPublicSchemaHelper,
+  getDataStoresHelper,
+  getDestinationDataStoresHelper,
+  getEventStoresHelper,
+  getExternalConsumerSchemasHelper,
   getPublicSchemasForOperationHelper,
   getPublicSchemasHelper,
+  getSourceDataStoresHelper,
 } from "./manifest-helpers";
+import {
+  type ExternalPublicSchemaReference,
+  type ManifestError,
+  type VerificationResult,
+  verifyManifests,
+} from "./verify-manifest";
 
 const log = getLogger("sync-manifest");
 
@@ -35,11 +38,12 @@ export type Connection = {
   config: z.infer<typeof ConnectionConfigSchema>;
 };
 
+export type DataStoreConfig = z.infer<typeof DataStoreConfigSchema>;
+
 export type SourceDataStore = {
   sourceManifestSlug: string;
   connectionSlug: string;
-  publicationName: string;
-  slotName: string;
+  config: DataStoreConfig;
   connection: Connection;
 };
 

--- a/packages/sync/src/_test/in-memory-adapter.ts
+++ b/packages/sync/src/_test/in-memory-adapter.ts
@@ -1,15 +1,21 @@
-import type { CreateSourceOptions, IConnectionAdapter } from "@rejot-dev/contract/adapter";
-import { InMemorySource } from "./in-memory-source";
-import { InMemoryConnectionConfigSchema } from "@rejot-dev/contract/manifest";
 import { z } from "zod";
+
+import type { IConnectionAdapter } from "@rejot-dev/contract/adapter";
+import {
+  InMemoryConnectionConfigSchema,
+  type InMemoryDataStoreConfigSchema,
+} from "@rejot-dev/contract/manifest";
+import type { IConnection } from "@rejot-dev/contract/sync";
+
 import { InMemoryEventStore } from "./in-memory-event-store";
 import { InMemorySink } from "./in-memory-sink";
-import type { IConnection } from "@rejot-dev/contract/sync";
+import { InMemorySource } from "./in-memory-source";
 
 export class InMemoryConnectionAdapter
   implements
     IConnectionAdapter<
       z.infer<typeof InMemoryConnectionConfigSchema>,
+      z.infer<typeof InMemoryDataStoreConfigSchema>,
       InMemorySource,
       InMemorySink,
       InMemoryEventStore
@@ -25,7 +31,7 @@ export class InMemoryConnectionAdapter
   createSource(
     _connectionSlug: string,
     _connection: z.infer<typeof InMemoryConnectionConfigSchema>,
-    _options?: CreateSourceOptions,
+    _options: z.infer<typeof InMemoryDataStoreConfigSchema>,
   ): InMemorySource {
     let source = this.#sources.get(_connectionSlug);
     if (!source) {

--- a/packages/sync/src/manifest/validate-manifest.ts
+++ b/packages/sync/src/manifest/validate-manifest.ts
@@ -50,7 +50,9 @@ function formatValidationResult(result: ValidationResult): string {
   return output;
 }
 
-export async function validateManifest(manifest: z.infer<typeof SyncManifestSchema>) {
+export async function validateManifest(
+  manifest: z.infer<typeof SyncManifestSchema>,
+): Promise<void> {
   const consumerSchemaValidationAdapters: AnyIConsumerSchemaValidationAdapter[] = [
     new PostgresConsumerSchemaValidationAdapter(),
   ];

--- a/packages/sync/src/sync-controller/source-reader.ts
+++ b/packages/sync/src/sync-controller/source-reader.ts
@@ -45,13 +45,7 @@ export class SourceReader {
   #createSources() {
     const sourceDataStores = this.#syncManifest.getSourceDataStores();
 
-    for (const {
-      sourceManifestSlug,
-      connectionSlug,
-      publicationName,
-      slotName,
-      connection,
-    } of sourceDataStores) {
+    for (const { sourceManifestSlug, connectionSlug, config, connection } of sourceDataStores) {
       const adapter = this.#connectionAdapters.find(
         (adapter) => adapter.connectionType === connection.config.connectionType,
       );
@@ -62,10 +56,7 @@ export class SourceReader {
         );
       }
 
-      const source = adapter.createSource(connectionSlug, connection.config, {
-        publicationName,
-        slotName,
-      });
+      const source = adapter.createSource(connectionSlug, connection.config, config);
 
       this.#sources.set(connectionSlug, {
         manifestSlug: sourceManifestSlug,

--- a/packages/sync/src/sync-manifest-controller.test.ts
+++ b/packages/sync/src/sync-manifest-controller.test.ts
@@ -1,17 +1,19 @@
-import { test, expect, describe } from "bun:test";
-import { SyncManifestController } from "./sync-manifest-controller";
+import { describe, expect, test } from "bun:test";
+
+import type { Transaction } from "@rejot-dev/contract/sync";
+
 import { InMemoryConnectionAdapter } from "./_test/in-memory-adapter";
 import { InMemoryEventStore } from "./_test/in-memory-event-store";
-import type { Transaction } from "@rejot-dev/contract/sync";
-import type { ISyncHTTPController } from "./sync-http-service/sync-http-service";
 import type { ISyncServiceResolver } from "./sync-http-service/sync-http-resolver";
+import type { ISyncHTTPController } from "./sync-http-service/sync-http-service";
+import { SyncManifestController } from "./sync-manifest-controller";
 
 class TestSyncHTTPController implements ISyncHTTPController {
-  async start(): Promise<void> {
+  start(): Promise<void> {
     return Promise.resolve();
   }
 
-  async stop(): Promise<void> {
+  stop(): Promise<void> {
     return Promise.resolve();
   }
 }

--- a/packages/sync/src/sync-manifest-controller.ts
+++ b/packages/sync/src/sync-manifest-controller.ts
@@ -73,7 +73,7 @@ export class SyncManifestController {
     const sourceDataStores = this.#syncManifest.getSourceDataStores();
     const destinationDataStores = this.#syncManifest.getDestinationDataStores();
 
-    for (const { connectionSlug, publicationName, slotName, connection } of sourceDataStores) {
+    for (const { connectionSlug, config, connection } of sourceDataStores) {
       const adapter = this.#connectionAdapters.find(
         (adapter) => adapter.connectionType === connection.config.connectionType,
       );
@@ -84,10 +84,7 @@ export class SyncManifestController {
         );
       }
 
-      const source = adapter.createSource(connectionSlug, connection.config, {
-        publicationName,
-        slotName,
-      });
+      const source = adapter.createSource(connectionSlug, connection.config, config);
 
       this.#sources.set(connectionSlug, source);
     }

--- a/scripts/check-workspace-refs.ts
+++ b/scripts/check-workspace-refs.ts
@@ -1,12 +1,13 @@
 #!/usr/bin/env bun
 
 import { $ } from "bun";
-import { readFileSync, writeFileSync, existsSync } from "fs";
-import { join, relative, dirname } from "path";
+import { existsSync, readFileSync, writeFileSync } from "fs";
+import { dirname, join, relative } from "path";
+
 import {
-  parseWorkspacePackages,
-  findWorkspaceReferences,
   checkTsConfigReferences,
+  findWorkspaceReferences,
+  parseWorkspacePackages,
   type WorkspacePackage,
 } from "./workspace-utils";
 
@@ -37,7 +38,7 @@ async function main() {
     let hasUpdates = false;
 
     const result = await $`bun pm ls`.quiet();
-    const packages = await parseWorkspacePackages(await result.text());
+    const packages = await parseWorkspacePackages(result.text());
 
     for (const pkg of packages) {
       const packageJsonPath = join(process.cwd(), pkg.path, "package.json");

--- a/scripts/workspace-utils.ts
+++ b/scripts/workspace-utils.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
-import { readFileSync, existsSync, readdirSync } from "fs";
-import { join, relative, dirname } from "path";
+import { existsSync, readdirSync, readFileSync } from "fs";
+import { dirname, join, relative } from "path";
 
 export type WorkspacePackage = {
   name: string;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,7 +6,7 @@
     "module": "ESNext",
     "moduleDetection": "force",
     "jsx": "react-jsx",
-    "allowJs": true,
+    "allowJs": false,
     // Bundler mode
     "moduleResolution": "bundler",
     "verbatimModuleSyntax": true,
@@ -17,6 +17,8 @@
     "declarationMap": true,
     "sourceMap": true,
     "emitDeclarationOnly": true,
+    "isolatedDeclarations": false,
+    "isolatedModules": true,
     // Best practices
     "strict": true,
     "skipLibCheck": true,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Updated data store configuration in the contract to be specific to each connection type, starting with Postgres and in-memory. This makes it easier to add new data store types and ensures correct config handling.

- **Refactors**
  - Data store config is now a discriminated union based on connection type.
  - CLI, manifest, adapters, and tests updated to use the new config structure.

<!-- End of auto-generated description by mrge. -->

