### PR TITLE
introspection: add db query tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ yarn-error.log*
 .output
 
 *.log
+
+rejot-manifest.json

--- a/apps/mcp/_test/mcp-integration-test-example-schema.ts.ignore
+++ b/apps/mcp/_test/mcp-integration-test-example-schema.ts.ignore
@@ -4,8 +4,8 @@ import {
   createPostgresConsumerSchemaTransformation,
   createPostgresPublicSchemaTransformation,
 } from "@rejot-dev/adapter-postgres";
-import { createPublicSchema } from "@rejot-dev/contract/public-schema";
 import { createConsumerSchema } from "@rejot-dev/contract/consumer-schema";
+import { createPublicSchema } from "@rejot-dev/contract/public-schema";
 
 const testPublicSchema = createPublicSchema("public-account", {
   source: { dataStoreSlug: "data-store-1", tables: ["account"] },

--- a/apps/mcp/_test/mcp.integration.test.ts
+++ b/apps/mcp/_test/mcp.integration.test.ts
@@ -1,10 +1,13 @@
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+
+import { cp, mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { parsePostgresConnectionString } from "@rejot-dev/adapter-postgres/postgres-client";
+
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { parsePostgresConnectionString } from "@rejot-dev/adapter-postgres/postgres-client";
-import { mkdtemp, rm, mkdir, cp } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join, dirname } from "node:path";
-import { afterAll, beforeAll, describe, expect, test } from "vitest";
 
 interface ToolResponse {
   content: Array<{
@@ -169,7 +172,10 @@ describe.skipIf(!process.env.REJOT_SYNC_CLI_TEST_CONNECTION)("MCP Integration Te
       const testDir = join(tmpDir, subDir, "_test");
       await mkdir(testDir);
       await cp(
-        join(dirname(new URL(import.meta.url).pathname), "mcp-integration-test-example-schema.ts"),
+        join(
+          dirname(new URL(import.meta.url).pathname),
+          "mcp-integration-test-example-schema.ts.ignore",
+        ),
         join(testDir, "mcp-integration-test-example-schema.ts"),
       );
 

--- a/apps/mcp/collect/collect.tool.ts
+++ b/apps/mcp/collect/collect.tool.ts
@@ -1,10 +1,13 @@
-import { z } from "zod";
-import type { IRejotMcp, IFactory } from "@/rejot-mcp";
-import type { McpState } from "@/state/mcp-state";
-import type { IWorkspaceService } from "@rejot-dev/contract/workspace";
-import { getLogger } from "@rejot-dev/contract/logger";
-import { type IVibeCollector } from "@rejot-dev/contract-tools/collect/vibe-collect";
 import { join } from "node:path";
+
+import { z } from "zod";
+
+import { getLogger } from "@rejot-dev/contract/logger";
+import type { IWorkspaceService } from "@rejot-dev/contract/workspace";
+import { type IVibeCollector } from "@rejot-dev/contract-tools/collect/vibe-collect";
+
+import type { IFactory, IRejotMcp } from "@/rejot-mcp";
+import type { McpState } from "@/state/mcp-state";
 
 const log = getLogger(import.meta.url);
 
@@ -67,11 +70,13 @@ export class CollectTool implements IFactory {
         log.info("collection results", Array.from(collectionResults.keys()));
 
         // Write to manifests if requested
-        if (write) {
+        if (write && collectionResults.size > 0) {
           await this.#vibeCollector.writeToManifests(collectionResults);
           outputContent.push({
             type: "text" as const,
-            text: "Successfully wrote all schemas to their respective manifests",
+            text: `Successfully wrote all schemas to their respective manifests: ${Array.from(
+              collectionResults.keys(),
+            ).join(", ")}`,
           });
         } else {
           outputContent.push({

--- a/apps/mcp/tools/manifest-connection/manifest-connection.tool.ts
+++ b/apps/mcp/tools/manifest-connection/manifest-connection.tool.ts
@@ -1,12 +1,15 @@
+import { join } from "node:path";
+
+import { z } from "zod";
+
+import { PostgresConnectionSchema } from "@rejot-dev/adapter-postgres/schemas";
+import type { IWorkspaceService } from "@rejot-dev/contract/workspace";
+import { writeManifest } from "@rejot-dev/contract-tools/manifest";
+import { mergeAndUpdateManifest } from "@rejot-dev/contract-tools/manifest/manifest.fs";
+import { getManifestBySlug } from "@rejot-dev/contract-tools/manifest/manifest-workspace-resolver";
+
 import type { IFactory, IRejotMcp } from "@/rejot-mcp";
 import type { McpState } from "@/state/mcp-state";
-import { PostgresConnectionSchema } from "@rejot-dev/adapter-postgres/schemas";
-import { writeManifest } from "@rejot-dev/contract-tools/manifest";
-import { getManifestBySlug } from "@rejot-dev/contract-tools/manifest/manifest-workspace-resolver";
-import { mergeAndUpdateManifest } from "@rejot-dev/contract-tools/manifest/manifest.fs";
-import type { IWorkspaceService } from "@rejot-dev/contract/workspace";
-import { join } from "node:path";
-import { z } from "zod";
 
 export class ManifestConnectionTool implements IFactory {
   #workspaceService: IWorkspaceService;

--- a/apps/rejot-cli/_test/example-schema.ts
+++ b/apps/rejot-cli/_test/example-schema.ts
@@ -4,8 +4,8 @@ import {
   createPostgresConsumerSchemaTransformation,
   createPostgresPublicSchemaTransformation,
 } from "@rejot-dev/adapter-postgres";
-import { createPublicSchema } from "@rejot-dev/contract/public-schema";
 import { createConsumerSchema } from "@rejot-dev/contract/consumer-schema";
+import { createPublicSchema } from "@rejot-dev/contract/public-schema";
 
 const testPublicSchema = createPublicSchema("public-account", {
   source: { dataStoreSlug: "data-store-1", tables: ["account"] },

--- a/packages/adapter-postgres/src/postgres-schemas.ts
+++ b/packages/adapter-postgres/src/postgres-schemas.ts
@@ -23,6 +23,8 @@ export const PostgresConsumerSchemaTransformationSchema = z.object({
 
 export const PostgresDataStoreSchema = z.object({
   connectionType: z.literal("postgres").describe("Postgres connection type."),
-  publicationName: z.string().describe("Name of the publication (for Postgres)."),
-  slotName: z.string().describe("Name of the replication slot (for Postgres)."),
+  slotName: z.string().describe("Name of the replication slot."),
+  publicationName: z.string().describe("Name of the publication."),
+  tables: z.array(z.string()).describe("Tables to replicate.").optional(),
+  allTables: z.boolean().describe("When true, all tables are replicated.").optional(),
 });

--- a/packages/contract-tools/collect/vibe-collect.test.ts
+++ b/packages/contract-tools/collect/vibe-collect.test.ts
@@ -1,10 +1,12 @@
-import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join, dirname } from "node:path";
-import type { PublicSchemaData } from "@rejot-dev/contract/public-schema";
-import type { ConsumerSchemaData } from "@rejot-dev/contract/consumer-schema";
+import { dirname, join } from "node:path";
+
 import type { CollectedSchemas, ISchemaCollector } from "@rejot-dev/contract/collect";
+import type { ConsumerSchemaData } from "@rejot-dev/contract/consumer-schema";
+import type { PublicSchemaData } from "@rejot-dev/contract/public-schema";
 
 import { VibeCollector } from "./vibe-collect";
 

--- a/packages/contract-tools/collect/vibe-collect.ts
+++ b/packages/contract-tools/collect/vibe-collect.ts
@@ -1,12 +1,15 @@
+import { dirname, join, relative } from "node:path";
+
 import { z } from "zod";
-import { dirname, relative, join } from "node:path";
-import { searchInDirectory } from "./file-finder";
-import { collectGitIgnore } from "./git-ignore";
+
 import { type ISchemaCollector } from "@rejot-dev/contract/collect";
+import { getLogger } from "@rejot-dev/contract/logger";
+import type { ConsumerSchemaSchema, PublicSchemaSchema } from "@rejot-dev/contract/manifest";
+
 import { readManifest, writeManifest } from "../manifest";
 import { ManifestPrinter } from "../manifest/manifest-printer";
-import { getLogger } from "@rejot-dev/contract/logger";
-import type { PublicSchemaSchema, ConsumerSchemaSchema } from "@rejot-dev/contract/manifest";
+import { searchInDirectory } from "./file-finder";
+import { collectGitIgnore } from "./git-ignore";
 
 const log = getLogger(import.meta.url);
 
@@ -62,7 +65,7 @@ export class VibeCollector implements IVibeCollector {
     const publicResults = await searchInDirectory(
       rootPath,
       ["createPublicSchema", "createConsumerSchema"],
-      { ignorePatterns, caseSensitive: true },
+      { ignorePatterns, caseSensitive: true, fileExtensions: ["ts", "js", "tsx", "jsx"] },
     );
 
     // Extract unique file paths

--- a/packages/contract-tools/manifest/manifest-printer.ts
+++ b/packages/contract-tools/manifest/manifest-printer.ts
@@ -1,14 +1,16 @@
 import { z } from "zod";
+
+import { JsonSchemaPrinter } from "@rejot-dev/contract/json-schema";
 import {
-  SyncManifestSchema,
   ConnectionSchema,
-  type PublicSchemaSchema,
   type ConsumerSchemaSchema,
   type DataStoreConfigSchema,
+  type PublicSchemaSchema,
+  SyncManifestSchema,
 } from "@rejot-dev/contract/manifest";
 import type { SyncManifest } from "@rejot-dev/contract/sync-manifest";
+
 import type { WorkspaceDefinition } from "./manifest-workspace-resolver";
-import { JsonSchemaPrinter } from "@rejot-dev/contract/json-schema";
 
 type Manifest = z.infer<typeof SyncManifestSchema>;
 type Connection = z.infer<typeof ConnectionSchema>;

--- a/packages/contract/adapter/adapter.ts
+++ b/packages/contract/adapter/adapter.ts
@@ -1,22 +1,22 @@
 import { z } from "zod";
 
-import type {
-  IDataSink,
-  IDataSource,
-  TransformedOperation,
-  TableOperation,
-  IConnection,
-} from "../sync/sync.ts";
 import { type Cursor } from "../cursor/cursors";
+import type { IEventStore, TransformedOperationWithSource } from "../event-store/event-store.ts";
 import {
   ConnectionConfigSchema,
-  ConsumerSchemaTransformationSchema,
-  PublicSchemaTransformationSchema,
   type ConsumerSchemaSchema,
+  ConsumerSchemaTransformationSchema,
   type DataStoreConfigSchema,
   type PublicSchemaSchema,
+  PublicSchemaTransformationSchema,
 } from "../manifest/manifest.ts";
-import type { IEventStore, TransformedOperationWithSource } from "../event-store/event-store.ts";
+import type {
+  IConnection,
+  IDataSink,
+  IDataSource,
+  TableOperation,
+  TransformedOperation,
+} from "../sync/sync.ts";
 
 // Define ValidationResult interface at the contract level
 export interface ValidationResult {
@@ -159,6 +159,7 @@ export interface IIntrospectionAdapter<
   getTables(connectionSlug: string): Promise<{ schema: string; name: string }[]>;
   getTableSchema(connectionSlug: string, tableName: string): Promise<Table>;
   getAllTableSchemas(connectionSlug: string): Promise<Map<string, Table>>;
+  executeQueries(connectionSlug: string, queries: string[]): Promise<Record<string, unknown>[][]>;
 }
 
 export type AnyIIntrospectionAdapter = IIntrospectionAdapter<

--- a/packages/contract/json-schema/json-schema.test.ts
+++ b/packages/contract/json-schema/json-schema.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+
 import { readFile } from "node:fs/promises";
 
 import type { JsonSchema7Type } from "zod-to-json-schema";

--- a/packages/contract/manifest/manifest-helpers.ts
+++ b/packages/contract/manifest/manifest-helpers.ts
@@ -1,8 +1,10 @@
 import { z } from "zod";
-import type { SyncManifestSchema, ConsumerSchemaSchema, PublicSchemaSchema } from "./manifest";
+
 import type { TransformedOperationWithSource } from "@rejot-dev/contract/event-store";
-import type { Connection, SourceDataStore, DestinationDataStore, Operation } from "./sync-manifest";
 import type { WorkspaceDefinition } from "@rejot-dev/contract-tools/manifest";
+
+import type { ConsumerSchemaSchema, PublicSchemaSchema, SyncManifestSchema } from "./manifest";
+import type { Connection, DestinationDataStore, Operation, SourceDataStore } from "./sync-manifest";
 
 type Manifest = z.infer<typeof SyncManifestSchema>;
 

--- a/packages/sync/src/manifest/validate-manifest.ts
+++ b/packages/sync/src/manifest/validate-manifest.ts
@@ -1,11 +1,12 @@
+import { z } from "zod";
+
+import { PostgresConsumerSchemaValidationAdapter } from "@rejot-dev/adapter-postgres";
 import type {
   AnyIConsumerSchemaValidationAdapter,
-  ValidationResult,
   ValidationError,
+  ValidationResult,
 } from "@rejot-dev/contract/adapter";
 import type { SyncManifestSchema } from "@rejot-dev/contract/manifest";
-import { PostgresConsumerSchemaValidationAdapter } from "@rejot-dev/adapter-postgres";
-import { z } from "zod";
 
 /**
  * Formats a validation error for display

--- a/packages/sync/src/sync-controller/source-reader.ts
+++ b/packages/sync/src/sync-controller/source-reader.ts
@@ -1,7 +1,8 @@
 import type { AnyIConnectionAdapter } from "@rejot-dev/contract/adapter";
-import type { IDataSource, Transaction } from "@rejot-dev/contract/sync";
-import type { SyncManifest } from "../../../contract/manifest/sync-manifest";
 import { getLogger } from "@rejot-dev/contract/logger";
+import type { IDataSource, Transaction } from "@rejot-dev/contract/sync";
+
+import type { SyncManifest } from "../../../contract/manifest/sync-manifest";
 
 const log = getLogger("source-reader");
 

--- a/packages/sync/src/sync-manifest-controller.ts
+++ b/packages/sync/src/sync-manifest-controller.ts
@@ -1,18 +1,19 @@
 import { z } from "zod";
-import { SyncManifestSchema } from "@rejot-dev/contract/manifest";
-import { getLogger } from "@rejot-dev/contract/logger";
+
 import type {
   AnyIConnectionAdapter,
   AnyIPublicSchemaTransformationAdapter,
 } from "@rejot-dev/contract/adapter";
-import type { IDataSink, IDataSource, Transaction } from "@rejot-dev/contract/sync";
 import type { IEventStore, TransformedOperationWithSource } from "@rejot-dev/contract/event-store";
-import { SyncManifest } from "../../contract/manifest/sync-manifest";
+import { getLogger } from "@rejot-dev/contract/logger";
+import { SyncManifestSchema } from "@rejot-dev/contract/manifest";
+import { SchemaValidator } from "@rejot-dev/contract/schema-validator";
+import type { IDataSink, IDataSource, Transaction } from "@rejot-dev/contract/sync";
 
+import { SyncManifest } from "../../contract/manifest/sync-manifest";
+import type { ISyncServiceResolver } from "./sync-http-service/sync-http-resolver";
 import { type ISyncHTTPController } from "./sync-http-service/sync-http-service";
 import { fetchRead } from "./sync-http-service/sync-http-service-fetch";
-import type { ISyncServiceResolver } from "./sync-http-service/sync-http-resolver";
-import { SchemaValidator } from "@rejot-dev/contract/schema-validator";
 
 const log = getLogger("sync-manifest-controller");
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Added a tool to execute SQL queries directly on a database connection for introspection and testing.

- **New Features**
  - Added `executeQueries` method to the Postgres introspection adapter.
  - Exposed a new MCP tool to run one or more SQL queries on a configured database connection.

<!-- End of auto-generated description by mrge. -->

