### PR TITLE
Chore: refactor so contract doesn't depend on contract-tools

### DIFF
--- a/apps/mcp/collect/collect.tool.ts
+++ b/apps/mcp/collect/collect.tool.ts
@@ -1,10 +1,9 @@
 import { join } from "node:path";
 
-import { z } from "zod";
-
 import { getLogger } from "@rejot-dev/contract/logger";
-import type { IWorkspaceService } from "@rejot-dev/contract/workspace";
 import { type IVibeCollector } from "@rejot-dev/contract-tools/collect/vibe-collect";
+import type { IWorkspaceService } from "@rejot-dev/contract-tools/manifest/manifest-workspace-resolver";
+import { z } from "zod";
 
 import type { IFactory, IRejotMcp } from "@/rejot-mcp";
 import type { McpState } from "@/state/mcp-state";

--- a/apps/mcp/index.ts
+++ b/apps/mcp/index.ts
@@ -1,19 +1,21 @@
-import { parseArgs } from "@std/cli/parse-args";
 import { join } from "node:path";
-import { RejotMcp } from "./rejot-mcp";
-import { WorkspaceResources } from "./workspace/workspace.resources";
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { SchemaCollector } from "@rejot-dev/contract/collect";
+import { FileLogger, setLogger } from "@rejot-dev/contract/logger";
+import { VibeCollector } from "@rejot-dev/contract-tools/collect/vibe-collect";
 import { ManifestWorkspaceResolver } from "@rejot-dev/contract-tools/manifest";
+import { WorkspaceService } from "@rejot-dev/contract-tools/manifest/manifest-workspace-resolver";
+import { parseArgs } from "@std/cli/parse-args";
+
+import { CollectTool } from "./collect/collect.tool";
+import { RejotMcp } from "./rejot-mcp";
 import { DbIntrospectionTool } from "./tools/db-introspection/db-introspection.tool";
 import { ManifestInfoTool } from "./tools/manifest/manifest-info.tool";
-import { WorkspaceTool } from "./workspace/workspace.tool";
-import { setLogger, FileLogger } from "@rejot-dev/contract/logger";
-import { WorkspaceService } from "../../packages/contract/workspace/workspace";
-import { ManifestConnectionTool } from "./tools/manifest-connection/manifest-connection.tool";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ManifestInitTool } from "./tools/manifest/manifest-init.tool";
-import { CollectTool } from "./collect/collect.tool";
-import { VibeCollector } from "@rejot-dev/contract-tools/collect/vibe-collect";
-import { SchemaCollector } from "@rejot-dev/contract/collect";
+import { ManifestConnectionTool } from "./tools/manifest-connection/manifest-connection.tool";
+import { WorkspaceResources } from "./workspace/workspace.resources";
+import { WorkspaceTool } from "./workspace/workspace.tool";
 
 // Open the log file when starting up
 const args = parseArgs(process.argv.slice(2));

--- a/apps/mcp/tools/db-introspection/db-introspection.tool.ts
+++ b/apps/mcp/tools/db-introspection/db-introspection.tool.ts
@@ -5,8 +5,8 @@ import { PostgresIntrospectionAdapter } from "@rejot-dev/adapter-postgres";
 import type { AnyIConnectionAdapter, AnyIIntrospectionAdapter } from "@rejot-dev/contract/adapter";
 import { ConnectionConfigSchema } from "@rejot-dev/contract/manifest";
 import { getConnectionBySlugHelper } from "@rejot-dev/contract/manifest-helpers";
-import type { IWorkspaceService } from "@rejot-dev/contract/workspace";
-import type { WorkspaceDefinition } from "@rejot-dev/contract-tools/manifest";
+import type { IWorkspaceService } from "@rejot-dev/contract-tools/manifest/manifest-workspace-resolver";
+import type { WorkspaceDefinition } from "@rejot-dev/contract/workspace";
 
 import type { IFactory } from "@/rejot-mcp";
 import type { IRejotMcp } from "@/rejot-mcp";

--- a/apps/mcp/tools/manifest-connection/manifest-connection.tool.ts
+++ b/apps/mcp/tools/manifest-connection/manifest-connection.tool.ts
@@ -1,12 +1,12 @@
 import { join } from "node:path";
 
-import { z } from "zod";
-
 import { PostgresConnectionSchema } from "@rejot-dev/adapter-postgres/schemas";
-import type { IWorkspaceService } from "@rejot-dev/contract/workspace";
+import type { IWorkspaceService } from "@rejot-dev/contract-tools/manifest/manifest-workspace-resolver";
 import { writeManifest } from "@rejot-dev/contract-tools/manifest";
 import { mergeAndUpdateManifest } from "@rejot-dev/contract-tools/manifest/manifest.fs";
 import { getManifestBySlug } from "@rejot-dev/contract-tools/manifest/manifest-workspace-resolver";
+
+import { z } from "zod";
 
 import type { IFactory, IRejotMcp } from "@/rejot-mcp";
 import type { McpState } from "@/state/mcp-state";

--- a/apps/mcp/tools/manifest/manifest-info.tool.ts
+++ b/apps/mcp/tools/manifest/manifest-info.tool.ts
@@ -1,14 +1,16 @@
-import { z } from "zod";
-import { ManifestPrinter } from "@rejot-dev/contract-tools/manifest/manifest-printer";
-import { readManifest } from "@rejot-dev/contract-tools/manifest";
-import { verifyManifests } from "@rejot-dev/contract/manifest";
-import type { IRejotMcp, IFactory } from "@/rejot-mcp";
-import type { McpState } from "@/state/mcp-state";
 import { join } from "node:path";
-import { ensurePathRelative } from "@/util/fs.util";
-import type { IWorkspaceService } from "@rejot-dev/contract/workspace";
-import { SyncManifest } from "@rejot-dev/contract/sync-manifest";
+
+import { verifyManifests } from "@rejot-dev/contract/manifest";
 import { workspaceToManifests } from "@rejot-dev/contract/manifest-helpers";
+import { SyncManifest } from "@rejot-dev/contract/sync-manifest";
+import { readManifest } from "@rejot-dev/contract-tools/manifest";
+import { ManifestPrinter } from "@rejot-dev/contract-tools/manifest/manifest-printer";
+import type { IWorkspaceService } from "@rejot-dev/contract-tools/manifest/manifest-workspace-resolver";
+import { z } from "zod";
+
+import type { IFactory, IRejotMcp } from "@/rejot-mcp";
+import type { McpState } from "@/state/mcp-state";
+import { ensurePathRelative } from "@/util/fs.util";
 export class ManifestInfoTool implements IFactory {
   #workspaceService: IWorkspaceService;
 

--- a/apps/mcp/tools/manifest/manifest-init.tool.ts
+++ b/apps/mcp/tools/manifest/manifest-init.tool.ts
@@ -1,12 +1,14 @@
-import { z } from "zod";
-import { initManifest } from "@rejot-dev/contract-tools/manifest";
-import type { IRejotMcp, IFactory } from "@/rejot-mcp";
-import type { McpState } from "@/state/mcp-state";
 import { join } from "node:path";
-import { ensurePathRelative } from "@/util/fs.util";
+
 import { getLogger } from "@rejot-dev/contract/logger";
+import { initManifest } from "@rejot-dev/contract-tools/manifest";
 import { mergeAndUpdateManifest } from "@rejot-dev/contract-tools/manifest/manifest.fs";
-import type { IWorkspaceService } from "@rejot-dev/contract/workspace";
+import type { IWorkspaceService } from "@rejot-dev/contract-tools/manifest/manifest-workspace-resolver";
+import { z } from "zod";
+
+import type { IFactory, IRejotMcp } from "@/rejot-mcp";
+import type { McpState } from "@/state/mcp-state";
+import { ensurePathRelative } from "@/util/fs.util";
 
 const log = getLogger(import.meta.url);
 

--- a/apps/mcp/workspace/workspace.resources.test.ts
+++ b/apps/mcp/workspace/workspace.resources.test.ts
@@ -1,13 +1,14 @@
-import { describe, it, expect, mock } from "bun:test";
+import { describe, expect, it, mock } from "bun:test";
+
+import { WorkspaceDefinition } from "@rejot-dev/contract/workspace";
+import type { IManifestWorkspaceResolver, ManifestInfo } from "@rejot-dev/contract-tools/manifest";
+import {
+  WorkspaceService,
+  workspaceToSyncManifest,
+} from "@rejot-dev/contract-tools/manifest/manifest-workspace-resolver";
+
 import { MockRejotMcp } from "../_test/mock-mcp-server";
 import { WorkspaceResources } from "./workspace.resources";
-import type {
-  IManifestWorkspaceResolver,
-  WorkspaceDefinition,
-  ManifestInfo,
-} from "@rejot-dev/contract-tools/manifest";
-import { workspaceToSyncManifest } from "@rejot-dev/contract-tools/manifest/manifest-workspace-resolver";
-import { WorkspaceService } from "@rejot-dev/contract/workspace";
 
 // Create a sample manifest
 const createBasicManifest = (slug: string) => ({

--- a/apps/mcp/workspace/workspace.resources.ts
+++ b/apps/mcp/workspace/workspace.resources.ts
@@ -1,8 +1,10 @@
-import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { join } from "node:path";
 import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getLogger } from "@rejot-dev/contract/logger";
-import type { IWorkspaceService } from "@rejot-dev/contract/workspace";
+import type { IWorkspaceService } from "@rejot-dev/contract-tools/manifest/manifest-workspace-resolver";
+
 import type { IFactory, IRejotMcp } from "../rejot-mcp";
 import type { McpState } from "../state/mcp-state";
 const log = getLogger("mcp.workspace.resources");

--- a/apps/mcp/workspace/workspace.tool.ts
+++ b/apps/mcp/workspace/workspace.tool.ts
@@ -1,11 +1,13 @@
-import { z } from "zod";
-import { initManifest } from "@rejot-dev/contract-tools/manifest";
-import type { IRejotMcp, IFactory } from "@/rejot-mcp";
-import type { McpState } from "@/state/mcp-state";
 import { join } from "node:path";
-import type { IWorkspaceService } from "@rejot-dev/contract/workspace";
-import { ManifestPrinter } from "@rejot-dev/contract-tools/manifest/manifest-printer";
+
 import { getLogger } from "@rejot-dev/contract/logger";
+import { initManifest } from "@rejot-dev/contract-tools/manifest";
+import { ManifestPrinter } from "@rejot-dev/contract-tools/manifest/manifest-printer";
+import type { IWorkspaceService } from "@rejot-dev/contract-tools/manifest/manifest-workspace-resolver";
+import { z } from "zod";
+
+import type { IFactory, IRejotMcp } from "@/rejot-mcp";
+import type { McpState } from "@/state/mcp-state";
 
 const log = getLogger(import.meta.url);
 

--- a/packages/contract-tools/manifest/index.ts
+++ b/packages/contract-tools/manifest/index.ts
@@ -1,14 +1,13 @@
-export { ManifestPrinter } from "./manifest-printer";
 export {
+  findManifestPath,
+  initManifest,
   readManifestOrGetEmpty as readManifest,
   writeManifest,
-  initManifest,
-  findManifestPath,
 } from "./manifest.fs";
-export { ManifestWorkspaceResolver } from "./manifest-workspace-resolver";
+export { ManifestPrinter } from "./manifest-printer";
 export type {
   IManifestWorkspaceResolver,
-  WorkspaceDefinition,
-  ResolveWorkspaceOptions,
   ManifestInfo,
+  ResolveWorkspaceOptions,
 } from "./manifest-workspace-resolver";
+export { ManifestWorkspaceResolver } from "./manifest-workspace-resolver";

--- a/packages/contract-tools/manifest/manifest-printer.ts
+++ b/packages/contract-tools/manifest/manifest-printer.ts
@@ -1,5 +1,3 @@
-import { z } from "zod";
-
 import { JsonSchemaPrinter } from "@rejot-dev/contract/json-schema";
 import {
   ConnectionSchema,
@@ -10,7 +8,8 @@ import {
 } from "@rejot-dev/contract/manifest";
 import type { SyncManifest } from "@rejot-dev/contract/sync-manifest";
 
-import type { WorkspaceDefinition } from "./manifest-workspace-resolver";
+import type { WorkspaceDefinition } from "@rejot-dev/contract/workspace";
+import { z } from "zod";
 
 type Manifest = z.infer<typeof SyncManifestSchema>;
 type Connection = z.infer<typeof ConnectionSchema>;

--- a/packages/contract/manifest/manifest-helpers.ts
+++ b/packages/contract/manifest/manifest-helpers.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 
 import type { TransformedOperationWithSource } from "@rejot-dev/contract/event-store";
-import type { WorkspaceDefinition } from "@rejot-dev/contract-tools/manifest";
+
+import type { WorkspaceDefinition } from "@rejot-dev/contract/workspace";
 
 import type { ConsumerSchemaSchema, PublicSchemaSchema, SyncManifestSchema } from "./manifest";
 import type { Connection, DestinationDataStore, Operation, SourceDataStore } from "./sync-manifest";

--- a/packages/contract/workspace/workspace.ts
+++ b/packages/contract/workspace/workspace.ts
@@ -1,39 +1,16 @@
-import type {
-  IManifestWorkspaceResolver,
-  WorkspaceDefinition,
-} from "@rejot-dev/contract-tools/manifest";
-import { ReJotError } from "@rejot-dev/contract/error";
+import type { z } from "zod";
 
-export interface IWorkspaceService {
-  resolveWorkspace(projectDir: string): Promise<{ workspace: WorkspaceDefinition }>;
+import type { SyncManifestSchema } from "../manifest/manifest";
+
+export interface ManifestWithPath {
+  /** Path is relative to the rootPath in the workspace. */
+  path: string;
+  manifest: z.infer<typeof SyncManifestSchema>;
 }
 
-export class WorkspaceInitializationError extends ReJotError {
-  get name(): string {
-    return "WorkspaceInitializationError";
-  }
-}
-
-export class WorkspaceService implements IWorkspaceService {
-  readonly #workspaceResolver: IManifestWorkspaceResolver;
-
-  constructor(workspaceResolver: IManifestWorkspaceResolver) {
-    this.#workspaceResolver = workspaceResolver;
-  }
-
-  async resolveWorkspace(projectDir: string): Promise<{ workspace: WorkspaceDefinition }> {
-    const workspace = await this.#workspaceResolver.resolveWorkspace({
-      startDir: projectDir,
-    });
-
-    if (!workspace) {
-      throw new WorkspaceInitializationError("No workspace found in project directory").withHint(
-        "Create a new manifest if this is a new workspace",
-      );
-    }
-
-    return {
-      workspace,
-    };
-  }
+export interface WorkspaceDefinition {
+  /** Absolute path */
+  rootPath: string;
+  ancestor: ManifestWithPath;
+  children: ManifestWithPath[];
 }

--- a/packages/sync/src/sync-controller.ts
+++ b/packages/sync/src/sync-controller.ts
@@ -1,11 +1,14 @@
+import crypto from "node:crypto";
+
+import { getLogger } from "@rejot-dev/contract/logger";
 import type {
-  IDataSource,
   IDataSink,
+  IDataSource,
   Transaction,
   TransformedOperation,
 } from "@rejot-dev/contract/sync";
-import { getLogger } from "@rejot-dev/contract/logger";
-import { ResultSetStore, type BackfillSource } from "./result-set-store";
+
+import { type BackfillSource, ResultSetStore } from "./result-set-store";
 import { DEFAULT_BACKFILL_TIMEOUT_MS } from "./sync-consts";
 
 const log = getLogger("sync-controller");


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Refactored code to remove the dependency of the contract package on contract-tools, resolving circular imports and clarifying type ownership.

- **Refactors**
  - Moved shared types like WorkspaceDefinition and ManifestWithPath to the contract package.
  - Updated imports across mcp and contract-tools to use the new type locations.
  - Introduced a dedicated WorkspaceService in contract-tools for workspace resolution.

<!-- End of auto-generated description by mrge. -->

