### PR TITLE
Lint: add check for importing local package without adding it to depe…

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,6 +9,8 @@ import tseslint from "typescript-eslint";
 
 import eslint from "@eslint/js";
 
+import localImportCheck from "./scripts/eslint-plugin-local-import-check.js";
+
 const frontendAppFiles = ["apps/controller-spa/**/*.{ts,tsx}"];
 
 // TODO: We might start using this at a later point. https://github.com/sindresorhus/eslint-plugin-unicorn/tree/main
@@ -30,9 +32,11 @@ export default tseslint.config(
     plugins: {
       "simple-import-sort": eslintPluginSimpleImportSort,
       unicorn: eslintPluginUnicorn,
+      local: localImportCheck,
     },
     rules: {
       // ...unicornFixableRules,
+      "local/require-local-package-deps": "warn", // TODO: make this an error once dependency cycles are resolved
       "@typescript-eslint/no-unused-vars": [
         "error",
         {

--- a/scripts/eslint-plugin-local-import-check.js
+++ b/scripts/eslint-plugin-local-import-check.js
@@ -1,0 +1,95 @@
+// eslint-plugin-local-import-check.js
+import console from "node:console";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Find the closest package.json above `startDir`.
+ * Stops at the filesystem root or on parse failure.
+ */
+function findPackageJson(startDir) {
+  let currentDir = startDir;
+
+  while (true) {
+    const packagePath = path.join(currentDir, "package.json");
+
+    if (fs.existsSync(packagePath)) {
+      try {
+        const content = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+        return { path: packagePath, name: content.name, content };
+      } catch (error) {
+        console.error(`Cannot parse package.json at ${packagePath}:`, error);
+        return null; // Bail out on malformed JSON
+      }
+    }
+
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      return null; // Reached filesystem root with no package.json
+    }
+    currentDir = parentDir;
+  }
+}
+
+const rule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Ensure local monorepo packages are declared in dependencies",
+    },
+    schema: [],
+  },
+  create(context) {
+    const filename = context.getFilename();
+
+    // Skip untitled buffers such as <input> or <text>
+    if (!filename || filename.startsWith("<")) {
+      return {};
+    }
+
+    const fileDir = path.dirname(filename);
+    const packageInfo = findPackageJson(fileDir);
+
+    if (!packageInfo || !packageInfo.name) {
+      return {};
+    }
+    const currentPackageName = packageInfo.name;
+
+    const deps = {
+      ...(packageInfo.content.dependencies ?? {}),
+      ...(packageInfo.content.devDependencies ?? {}),
+      ...(packageInfo.content.peerDependencies ?? {}),
+    };
+
+    return {
+      ImportDeclaration(node) {
+        const importPath = node.source.value;
+
+        if (typeof importPath === "string" && importPath.startsWith("@rejot-dev/")) {
+          const [, scope, name] = importPath.match(/^(@[^/]+)\/([^/]+)/) ?? [];
+
+          if (scope && name) {
+            const packageName = `${scope}/${name}`;
+
+            if (packageName === currentPackageName) {
+              return;
+            }
+
+            if (!deps[packageName]) {
+              context.report({
+                node,
+                message: `Import "${importPath}" relies on "${packageName}", which is missing from dependencies in ${packageInfo.path}.`,
+              });
+            }
+          }
+        }
+      },
+    };
+  },
+};
+
+export default {
+  rules: {
+    "require-local-package-deps": rule,
+  },
+};


### PR DESCRIPTION
…ndencies
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Added an ESLint rule to check that local packages are listed in package.json dependencies when imported.

- **New Rule**
 - Reports an error if a local package (starting with @rejot-dev/) is imported but not declared in dependencies.

<!-- End of auto-generated description by mrge. -->

