### PR TITLE
MCP: Tools for working with public/consumer schemas

### DIFF
--- a/.cursor/rules/monorepo.mdc
+++ b/.cursor/rules/monorepo.mdc
@@ -42,6 +42,7 @@ Sort imports in this order (with blank line between categories):
 
 ## Other
 - Prefer to destruct objects in things like for-loops.
+- In Typescript, never use Array<T>, always use T[]
 
 ## API Development
 ### Architecture

--- a/apps/mcp/collect/collect.tool.ts
+++ b/apps/mcp/collect/collect.tool.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 
 import { z } from "zod";
 
+import { ManifestMerger } from "@rejot-dev/contract/manifest-merger";
 import { type IVibeCollector } from "@rejot-dev/contract-tools/collect/vibe-collect";
 import type { IWorkspaceService } from "@rejot-dev/contract-tools/manifest/manifest-workspace-resolver";
 
@@ -79,7 +80,7 @@ export class CollectTool implements IFactory {
           if (writeDiagnostics.length > 0) {
             outputContent.push({
               type: "text" as const,
-              text: this.#vibeCollector.formatMergeDiagnostics(writeDiagnostics, {
+              text: ManifestMerger.formatMergeDiagnostics(writeDiagnostics, {
                 workspaceRoot: workspace.rootPath,
               }),
             });

--- a/apps/mcp/state/mcp-state.ts
+++ b/apps/mcp/state/mcp-state.ts
@@ -1,17 +1,36 @@
-import { CombinedRejotMcpError } from "./mcp-error";
-import { getLogger } from "@rejot-dev/contract/logger";
-import type { ReJotError } from "@rejot-dev/contract/error";
+import { z } from "zod";
 
-const log = getLogger("mcp.state");
+import { PostgresConnectionAdapter } from "@rejot-dev/adapter-postgres";
+import { PostgresIntrospectionAdapter } from "@rejot-dev/adapter-postgres";
+import type { AnyIConnectionAdapter, AnyIIntrospectionAdapter } from "@rejot-dev/contract/adapter";
+import type { ReJotError } from "@rejot-dev/contract/error";
+import { getLogger } from "@rejot-dev/contract/logger";
+import type { ConnectionConfigSchema } from "@rejot-dev/contract/manifest";
+import { getConnectionBySlugHelper } from "@rejot-dev/contract/manifest-helpers";
+import type { WorkspaceDefinition } from "@rejot-dev/contract/workspace";
+
+import { CombinedRejotMcpError, ReJotMcpError } from "./mcp-error";
+
+const log = getLogger(import.meta.url);
 
 export type McpStateStatus = "uninitialized" | "initializing" | "ready" | "error";
+
+type ValidConnectionType = z.infer<typeof ConnectionConfigSchema>["connectionType"];
+
+interface AdapterPair {
+  connectionAdapter: AnyIConnectionAdapter;
+  introspectionAdapter: AnyIIntrospectionAdapter;
+}
 
 export class McpState {
   readonly #workspaceDirectoryPath: string;
   #initializationErrors: ReJotError[] = [];
 
+  #adapters: Map<ValidConnectionType, AdapterPair>;
+
   constructor(workspaceDirectoryPath: string) {
     this.#workspaceDirectoryPath = workspaceDirectoryPath;
+    this.#adapters = new Map();
   }
 
   get workspaceDirectoryPath(): string {
@@ -39,5 +58,86 @@ export class McpState {
       log.warn("assertIsInitialized failed");
       throw new CombinedRejotMcpError(this.#initializationErrors);
     }
+  }
+
+  async ensureConnection(
+    connectionSlug: string,
+    workspace: WorkspaceDefinition,
+  ): Promise<AdapterPair> {
+    const manifestConnection = getConnectionBySlugHelper(workspace, connectionSlug);
+    if (!manifestConnection) {
+      throw new ConnectionNotFoundError(connectionSlug);
+    }
+
+    const adapter = this.getOrSetAdapter(manifestConnection.config.connectionType);
+    const connection = adapter.connectionAdapter.getOrCreateConnection(
+      connectionSlug,
+      manifestConnection.config,
+    );
+
+    await connection.prepare();
+
+    return adapter;
+  }
+
+  getOrSetAdapter(connectionType: ValidConnectionType): AdapterPair {
+    const adapter = this.#adapters.get(connectionType);
+    if (adapter) {
+      return adapter;
+    }
+
+    // TODO(Wilco): here we hardcode the construction of (Postgres) connection adapter. At some point
+    //              in the future we should resolve this based on installed dependencies / manifest.
+
+    if (connectionType === "postgres") {
+      const postgresConnectionAdapter = new PostgresConnectionAdapter();
+      const postgresIntrospectionAdapter = new PostgresIntrospectionAdapter(
+        postgresConnectionAdapter,
+      );
+      const pair: AdapterPair = {
+        connectionAdapter: postgresConnectionAdapter,
+        introspectionAdapter: postgresIntrospectionAdapter,
+      };
+      this.#adapters.set("postgres", pair);
+      return pair;
+    }
+
+    throw new AdapterNotFoundError(connectionType).withHint(
+      "This is a user error. The ReJot manifest is using an adapter that the user has not installed.",
+    );
+  }
+}
+
+export class AdapterNotFoundError extends ReJotMcpError {
+  #connectionType: ValidConnectionType;
+
+  constructor(connectionType: ValidConnectionType) {
+    super(`No adapter found for connection type: ${connectionType}`);
+    this.#connectionType = connectionType;
+  }
+
+  get name(): string {
+    return "AdapterNotFoundError";
+  }
+
+  get connectionType(): ValidConnectionType {
+    return this.#connectionType;
+  }
+}
+
+export class ConnectionNotFoundError extends ReJotMcpError {
+  #connectionSlug: string;
+
+  constructor(connectionSlug: string) {
+    super(`Connection with slug ${connectionSlug} not found`);
+    this.#connectionSlug = connectionSlug;
+  }
+
+  get name(): string {
+    return "ConnectionNotFoundError";
+  }
+
+  get connectionSlug(): string {
+    return this.#connectionSlug;
   }
 }

--- a/apps/mcp/tools/manifest-connection/manifest-pg-datastore.tool.ts
+++ b/apps/mcp/tools/manifest-connection/manifest-pg-datastore.tool.ts
@@ -1,0 +1,268 @@
+import { join } from "node:path";
+
+import { z } from "zod";
+
+import type { PostgresConnectionAdapter } from "@rejot-dev/adapter-postgres";
+import { getAvailablePublications } from "@rejot-dev/adapter-postgres/replication-repository";
+import { getAvailableReplicationSlots } from "@rejot-dev/adapter-postgres/replication-repository";
+import { checkLogicalReplication } from "@rejot-dev/adapter-postgres/replication-repository";
+import { ManifestMerger } from "@rejot-dev/contract/manifest-merger";
+import type { IManifestFileManager } from "@rejot-dev/contract-tools/manifest/manifest-file-manager";
+import type { IWorkspaceService } from "@rejot-dev/contract-tools/manifest/manifest-workspace-resolver";
+import { getManifestBySlug } from "@rejot-dev/contract-tools/manifest/manifest-workspace-resolver";
+
+import type { IFactory, IRejotMcp } from "@/rejot-mcp";
+import type { McpState } from "@/state/mcp-state";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+export class ManifestPostgresDataStoreTool implements IFactory {
+  #workspaceService: IWorkspaceService;
+  #manifestFileManager: IManifestFileManager;
+
+  constructor(workspaceService: IWorkspaceService, manifestFileManager: IManifestFileManager) {
+    this.#workspaceService = workspaceService;
+    this.#manifestFileManager = manifestFileManager;
+  }
+
+  async initialize(_state: McpState): Promise<void> {
+    //
+  }
+
+  async register(mcp: IRejotMcp): Promise<void> {
+    mcp.registerTool(
+      "rejot_manifest_datastore_add_postgres_help",
+      "Get help on adding a postgres data store to a manifest.",
+      {
+        connectionSlug: z.string().describe("Slug of the connection to use for this data store."),
+      },
+      async ({ connectionSlug }) => {
+        const { workspace } = await this.#workspaceService.resolveWorkspace(
+          mcp.state.workspaceDirectoryPath,
+        );
+
+        const adapter = await mcp.state.ensureConnection(connectionSlug, workspace);
+
+        if (adapter.connectionAdapter.connectionType !== "postgres") {
+          return {
+            content: [
+              {
+                isError: true,
+                type: "text",
+                text: "Connection is not a postgres connection. This tool only works with postgres connections.",
+              },
+            ],
+          };
+        }
+
+        const postgresAdapter = adapter.connectionAdapter as PostgresConnectionAdapter;
+
+        // ! because connection was already ensured above.
+        const { client } = postgresAdapter.getConnection(connectionSlug)!;
+
+        const [hasLogicalReplication, availableReplicationSlots, availablePublications] =
+          await Promise.all([
+            checkLogicalReplication(client),
+            getAvailableReplicationSlots(client),
+            getAvailablePublications(client),
+          ]);
+
+        const content: CallToolResult["content"] = [];
+
+        if (!hasLogicalReplication) {
+          content.push({
+            type: "text",
+            text:
+              "Logical replication is not enabled for this Postgres database. This connectionSlug" +
+              " can still be added as data store, but logical replication needs to be enabled for it can be used to sync.",
+          });
+        }
+
+        // Add explanation about replication slots
+        content.push({
+          type: "text",
+          text: "## Replication Slots\n\nReplication slots are named entities in PostgreSQL that track the replication progress. They prevent the removal of WAL segments that might still be needed by consumers of the slot's changes. Replication slots are required for logical replication.",
+        });
+
+        // Show available replication slots
+        content.push({
+          type: "text",
+          text:
+            "### Available Replication Slots:\n\n" +
+            (availableReplicationSlots.length
+              ? availableReplicationSlots
+                  .map(
+                    (slot) =>
+                      `- ${slot.slotName} (Database: ${slot.database}, Active: ${slot.active})`,
+                  )
+                  .join("\n")
+              : "No replication slots found"),
+        });
+
+        // Show how to create replication slots
+        content.push({
+          type: "text",
+          text: "### Creating a Replication Slot\n\nUse the following SQL to create a logical replication slot:\n\n```sql\nSELECT pg_create_logical_replication_slot('rejot_slot', 'pgoutput');\n```",
+        });
+
+        // Add explanation about publications
+        content.push({
+          type: "text",
+          text: "## Publications\n\nPublications are a collection of tables whose changes will be sent to subscribers. They define which tables are part of the replication stream. Publications can include all tables or specific tables.",
+        });
+
+        // Show available publications
+        content.push({
+          type: "text",
+          text:
+            "### Available Publications:\n\n" +
+            (availablePublications.length
+              ? availablePublications
+                  .map((pub) => `- ${pub.pubName} (All Tables: ${pub.pubAllTables})`)
+                  .join("\n")
+              : "No publications found"),
+        });
+
+        // Show how to create publications
+        content.push({
+          type: "text",
+          text:
+            "### Creating a Publication\n\nUse one of the following SQL statements to create a publication:\n\n" +
+            "For all tables:\n```sql\nCREATE PUBLICATION your_publication_name FOR ALL TABLES;\n```\n\n" +
+            "For specific tables:\n```sql\nCREATE PUBLICATION your_publication_name FOR TABLE schema.table1, schema.table2;\n```",
+        });
+
+        return { content };
+      },
+    );
+    mcp.registerTool(
+      "rejot_manifest_datastore_add_postgres",
+      "Add a postgres data store to the specified manifest.",
+      {
+        manifestSlug: z.string().describe("The slug of the manifest available in the workspace."),
+        connectionSlug: z.string().describe("Slug of the connection to use for this data store."),
+        slotName: z.string().describe("Name of the replication slot."),
+        publicationName: z.string().describe("Name of the publication."),
+        tables: z.array(z.string()).describe("Tables to replicate.").optional(),
+        allTables: z.boolean().describe("When true, all tables are replicated.").optional(),
+      },
+      async ({ manifestSlug, connectionSlug, ...dataStoreConfig }) => {
+        const { workspace } = await this.#workspaceService.resolveWorkspace(
+          mcp.state.workspaceDirectoryPath,
+        );
+        const manifestWithPath = getManifestBySlug(workspace, manifestSlug);
+
+        if (!manifestWithPath) {
+          return {
+            content: [
+              {
+                isError: true,
+                type: "text",
+                text: `Manifest with slug '${manifestSlug}' not found.`,
+              },
+            ],
+          };
+        }
+
+        const { path } = manifestWithPath;
+        const manifestAbsolutePath = join(workspace.rootPath, path);
+
+        const { diagnostics } = await this.#manifestFileManager.mergeAndUpdateManifest(
+          manifestAbsolutePath,
+          [
+            {
+              dataStores: [
+                {
+                  connectionSlug,
+                  config: {
+                    connectionType: "postgres",
+                    slotName: dataStoreConfig.slotName,
+                    publicationName: dataStoreConfig.publicationName,
+                    tables: dataStoreConfig.tables,
+                    allTables: dataStoreConfig.allTables,
+                  },
+                },
+              ],
+            },
+          ],
+        );
+
+        const messages = [
+          `Added data store with connection slug '${connectionSlug}' to manifest '${manifestSlug}'.`,
+        ];
+
+        if (diagnostics.length > 0) {
+          messages.push(ManifestMerger.formatMergeDiagnostics(diagnostics));
+        }
+
+        return {
+          content: messages.map((text) => ({ type: "text", text })),
+        };
+      },
+    );
+
+    mcp.registerTool(
+      "rejot_manifest_datastore_remove",
+      "Remove a data store from the specified manifest.",
+      {
+        manifestSlug: z.string(),
+        connectionSlug: z.string(),
+      },
+      async ({ manifestSlug, connectionSlug }) => {
+        const { workspace } = await this.#workspaceService.resolveWorkspace(
+          mcp.state.workspaceDirectoryPath,
+        );
+
+        const manifestWithPath = getManifestBySlug(workspace, manifestSlug);
+
+        if (!manifestWithPath) {
+          return {
+            content: [{ type: "text", text: `Manifest with slug '${manifestSlug}' not found.` }],
+          };
+        }
+
+        const { manifest, path } = manifestWithPath;
+        const manifestAbsolutePath = join(workspace.rootPath, path);
+
+        if (!manifest.dataStores?.length) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `No data stores found in manifest '${manifestSlug}'.`,
+              },
+            ],
+          };
+        }
+
+        const existingDataStore = manifest.dataStores.find(
+          (ds) => ds.connectionSlug === connectionSlug,
+        );
+
+        if (!existingDataStore) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Data store with connection slug '${connectionSlug}' not found in manifest '${manifestSlug}'.`,
+              },
+            ],
+          };
+        }
+
+        manifest.dataStores = manifest.dataStores.filter(
+          (ds) => ds.connectionSlug !== connectionSlug,
+        );
+        await this.#manifestFileManager.writeManifest(manifestAbsolutePath, manifest);
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Successfully removed data store with connection slug '${connectionSlug}' from manifest '${manifestSlug}'.`,
+            },
+          ],
+        };
+      },
+    );
+  }
+}

--- a/apps/mcp/tools/schemas/schema.tool.ts
+++ b/apps/mcp/tools/schemas/schema.tool.ts
@@ -1,0 +1,191 @@
+import { z } from "zod";
+
+import { ConsumerSchemaSchema, PublicSchemaSchema } from "@rejot-dev/contract/manifest";
+import { ManifestPrinter } from "@rejot-dev/contract-tools/manifest/manifest-printer";
+import type { IWorkspaceService } from "@rejot-dev/contract-tools/manifest/manifest-workspace-resolver";
+
+import type { IFactory, IRejotMcp } from "@/rejot-mcp";
+import { McpState } from "@/state/mcp-state";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+export class SchemasTool implements IFactory {
+  #workspaceService: IWorkspaceService;
+
+  constructor(workspaceService: IWorkspaceService) {
+    this.#workspaceService = workspaceService;
+  }
+
+  async initialize(_state: McpState): Promise<void> {
+    // No initialization needed
+  }
+
+  async register(mcp: IRejotMcp): Promise<void> {
+    mcp.registerTool(
+      "rejot_find_public_schemas",
+      "Find public schemas in the workspace that match a regex pattern",
+      {
+        namePattern: z.string().describe("Regex pattern to match against schema names"),
+      },
+      async ({ namePattern }) => {
+        const { workspace } = await this.#workspaceService.resolveWorkspace(
+          mcp.state.workspaceDirectoryPath,
+        );
+
+        const pattern = new RegExp(namePattern);
+        const matchingSchemas: Array<{
+          schema: z.infer<typeof PublicSchemaSchema>;
+          manifestSlug: string;
+          manifestPath: string;
+        }> = [];
+
+        // Check schemas in the ancestor manifest
+        (workspace.ancestor.manifest.publicSchemas || []).forEach((schema) => {
+          if (pattern.test(schema.name)) {
+            matchingSchemas.push({
+              schema,
+              manifestSlug: workspace.ancestor.manifest.slug,
+              manifestPath: workspace.ancestor.path,
+            });
+          }
+        });
+
+        // Check schemas in child manifests
+        workspace.children.forEach((child) => {
+          (child.manifest.publicSchemas || []).forEach((schema) => {
+            if (pattern.test(schema.name)) {
+              matchingSchemas.push({
+                schema,
+                manifestSlug: child.manifest.slug,
+                manifestPath: child.path,
+              });
+            }
+          });
+        });
+
+        if (matchingSchemas.length === 0) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `No public schemas found matching pattern '${namePattern}'.`,
+              },
+            ],
+          };
+        }
+
+        const content: CallToolResult["content"] = [];
+
+        // Add summary of found schemas
+        content.push({
+          type: "text",
+          text: `Found ${matchingSchemas.length} public schema(s) matching pattern '${namePattern}':`,
+        });
+
+        for (const { schema, manifestSlug, manifestPath } of matchingSchemas) {
+          content.push({
+            type: "text",
+            text: `\n## ${schema.name}@v${schema.version.major}.${schema.version.minor}`,
+          });
+
+          content.push({
+            type: "text",
+            text: `Manifest: ${manifestSlug} (${manifestPath})`,
+          });
+
+          // Print detailed schema information using ManifestPrinter
+          const schemaDetails = ManifestPrinter.printPublicSchema([schema]);
+          content.push({
+            type: "text",
+            text: schemaDetails.join("\n"),
+          });
+        }
+
+        return { content };
+      },
+    );
+
+    mcp.registerTool(
+      "rejot_find_consumer_schemas",
+      "Find consumer schemas in the workspace that match a regex pattern",
+      {
+        namePattern: z.string().describe("Regex pattern to match against schema names"),
+      },
+      async ({ namePattern }) => {
+        const { workspace } = await this.#workspaceService.resolveWorkspace(
+          mcp.state.workspaceDirectoryPath,
+        );
+
+        const pattern = new RegExp(namePattern);
+        const matchingSchemas: Array<{
+          schema: z.infer<typeof ConsumerSchemaSchema>;
+          manifestSlug: string;
+          manifestPath: string;
+        }> = [];
+
+        // Check schemas in the ancestor manifest
+        (workspace.ancestor.manifest.consumerSchemas || []).forEach((schema) => {
+          if (pattern.test(schema.name)) {
+            matchingSchemas.push({
+              schema,
+              manifestSlug: workspace.ancestor.manifest.slug,
+              manifestPath: workspace.ancestor.path,
+            });
+          }
+        });
+
+        // Check schemas in child manifests
+        workspace.children.forEach((child) => {
+          (child.manifest.consumerSchemas || []).forEach((schema) => {
+            if (pattern.test(schema.name)) {
+              matchingSchemas.push({
+                schema,
+                manifestSlug: child.manifest.slug,
+                manifestPath: child.path,
+              });
+            }
+          });
+        });
+
+        if (matchingSchemas.length === 0) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `No consumer schemas found matching pattern '${namePattern}'.`,
+              },
+            ],
+          };
+        }
+
+        const content: CallToolResult["content"] = [];
+
+        // Add summary of found schemas
+        content.push({
+          type: "text",
+          text: `Found ${matchingSchemas.length} consumer schema(s) matching pattern '${namePattern}':`,
+        });
+
+        for (const { schema, manifestSlug, manifestPath } of matchingSchemas) {
+          content.push({
+            type: "text",
+            text: `\n## ${schema.name}`,
+          });
+
+          content.push({
+            type: "text",
+            text: `Manifest: ${manifestSlug} (${manifestPath})`,
+          });
+
+          // Print detailed schema information using ManifestPrinter
+          const schemaDetails = ManifestPrinter.printConsumerSchema([schema]);
+          content.push({
+            type: "text",
+            text: schemaDetails.join("\n"),
+          });
+        }
+
+        return { content };
+      },
+    );
+  }
+}

--- a/apps/mcp/workspace/workspace.tool.ts
+++ b/apps/mcp/workspace/workspace.tool.ts
@@ -94,6 +94,10 @@ export class WorkspaceTool implements IFactory {
             type: "text",
             text: ManifestPrinter.printManifestDiagnostics(diagnostics.errors).join("\n"),
           });
+          content.push({
+            type: "text",
+            text: "To fix these diagnostics, DO NOT edit the manifest. Update the underlying definition file and run collect.",
+          });
         }
 
         return {

--- a/apps/rejot-cli/_test/example-schema.ts
+++ b/apps/rejot-cli/_test/example-schema.ts
@@ -8,7 +8,7 @@ import { createConsumerSchema } from "@rejot-dev/contract/consumer-schema";
 import { createPublicSchema } from "@rejot-dev/contract/public-schema";
 
 const testPublicSchema = createPublicSchema("public-account", {
-  source: { dataStoreSlug: "data-store-1", tables: ["account"] },
+  source: { dataStoreSlug: "default-postgres", tables: ["account"] },
   outputSchema: z.object({
     id: z.number(),
     email: z.string(),
@@ -19,10 +19,6 @@ const testPublicSchema = createPublicSchema("public-account", {
       "account",
       "SELECT id, email, username as name FROM account WHERE id = $1",
     ),
-    createPostgresPublicSchemaTransformation(
-      "account_details",
-      "SELECT id, details FROM account_details WHERE account_id = $1",
-    ),
   ],
   version: {
     major: 1,
@@ -32,7 +28,7 @@ const testPublicSchema = createPublicSchema("public-account", {
 
 const testConsumerSchema = createConsumerSchema("consume-public-account", {
   source: {
-    manifestSlug: "default",
+    manifestSlug: "@rejot/",
     publicSchema: {
       name: "public-account",
       majorVersion: 1,

--- a/apps/rejot-cli/src/commands/workspace/workspace-info.command.ts
+++ b/apps/rejot-cli/src/commands/workspace/workspace-info.command.ts
@@ -1,0 +1,70 @@
+import { verifyWorkspace } from "@rejot-dev/contract/workspace";
+import { ManifestFileManager } from "@rejot-dev/contract-tools/manifest/manifest-file-manager";
+import { ManifestPrinter } from "@rejot-dev/contract-tools/manifest/manifest-printer";
+import { ManifestWorkspaceResolver } from "@rejot-dev/contract-tools/manifest/manifest-workspace-resolver";
+
+import { Command, Flags } from "@oclif/core";
+
+export class WorkspaceInfoCommand extends Command {
+  static override id = "workspace:info";
+  static override description =
+    "Display information about the current workspace configuration and diagnostics";
+
+  static override examples = [
+    "<%= config.bin %> workspace:info",
+    "<%= config.bin %> workspace:info --filename custom-manifest.json",
+  ];
+
+  static override flags = {
+    filename: Flags.string({
+      description: "Filename of the manifest file",
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { flags } = await this.parse(WorkspaceInfoCommand);
+
+    // Use ManifestFileManager to find the workspace path
+    const manifestFileManager = new ManifestFileManager();
+    const workspaceFilePath = await manifestFileManager.findManifestPath(
+      process.cwd(),
+      flags.filename,
+    );
+
+    if (!workspaceFilePath) {
+      this.error(`Workspace manifest file not found. Use 'rejot workspace:init' to create one.`);
+    }
+
+    // Resolve the workspace
+    const workspaceResolver = new ManifestWorkspaceResolver();
+    const workspace = await workspaceResolver.resolveWorkspace({
+      startDir: process.cwd(),
+      filename: flags.filename,
+    });
+
+    if (!workspace) {
+      this.error(`No workspace found. Use 'rejot workspace:init' to create one.`);
+    }
+
+    // Print workspace information
+    const workspaceInfo = ManifestPrinter.printWorkspace(workspace);
+    for (const line of workspaceInfo) {
+      this.log(line);
+    }
+
+    // Print diagnostics
+    const diagnostics = verifyWorkspace(workspace);
+
+    if (diagnostics.errors.length > 0) {
+      this.log("");
+      const diagnosticOutput = ManifestPrinter.printManifestDiagnostics(diagnostics.errors);
+      for (const line of diagnosticOutput) {
+        this.log(line);
+      }
+    }
+
+    if (!diagnostics.isValid) {
+      this.exit(1);
+    }
+  }
+}

--- a/apps/rejot-cli/src/index.ts
+++ b/apps/rejot-cli/src/index.ts
@@ -1,20 +1,22 @@
-import SyncCommand from "./commands/sync-command.ts";
+import { ConsoleLogger } from "@rejot-dev/contract/logger";
+import { setLogger } from "@rejot-dev/contract/logger";
+
 import CollectCommand from "./commands/collect-command.ts";
 import { ManifestInfoCommand } from "./commands/manifest/manifest-info.command.ts";
 import { ManifestInitCommand } from "./commands/manifest/manifest-init.command.ts";
+import { ManifestSyncCommand } from "./commands/manifest/manifest-sync.command.ts";
 import { ManifestConnectionAddCommand } from "./commands/manifest-connection/manifest-connection-add.command.ts";
-import { ManifestConnectionRemoveCommand } from "./commands/manifest-connection/manifest-connection-remove.command.ts";
 import { ManifestConnectionListCommand } from "./commands/manifest-connection/manifest-connection-list.command.ts";
+import { ManifestConnectionRemoveCommand } from "./commands/manifest-connection/manifest-connection-remove.command.ts";
 import { ManifestConnectionUpdateCommand } from "./commands/manifest-connection/manifest-connection-update.command.ts";
 import { ManifestDataStoreAddCommand } from "./commands/manifest-datastore/manifest-datastore-add.command.ts";
-import { ManifestDataStoreRemoveCommand } from "./commands/manifest-datastore/manifest-datastore-remove.command.ts";
 import { ManifestDataStoreListCommand } from "./commands/manifest-datastore/manifest-datastore-list.command.ts";
+import { ManifestDataStoreRemoveCommand } from "./commands/manifest-datastore/manifest-datastore-remove.command.ts";
 import { ManifestEventStoreAddCommand } from "./commands/manifest-eventstore/manifest-eventstore-add.command.ts";
-import { ManifestEventStoreRemoveCommand } from "./commands/manifest-eventstore/manifest-eventstore-remove.command.ts";
 import { ManifestEventStoreListCommand } from "./commands/manifest-eventstore/manifest-eventstore-list.command.ts";
-import { ManifestSyncCommand } from "./commands/manifest/manifest-sync.command.ts";
-import { ConsoleLogger } from "@rejot-dev/contract/logger";
-import { setLogger } from "@rejot-dev/contract/logger";
+import { ManifestEventStoreRemoveCommand } from "./commands/manifest-eventstore/manifest-eventstore-remove.command.ts";
+import SyncCommand from "./commands/sync-command.ts";
+import { WorkspaceInfoCommand } from "./commands/workspace/workspace-info.command.ts";
 
 export const commands = {
   sync: SyncCommand,
@@ -32,6 +34,7 @@ export const commands = {
   "manifest:eventstore:remove": ManifestEventStoreRemoveCommand,
   "manifest:eventstore:list": ManifestEventStoreListCommand,
   "manifest:sync": ManifestSyncCommand,
+  "workspace:info": WorkspaceInfoCommand,
 };
 
 setLogger(new ConsoleLogger("DEBUG"));

--- a/packages/adapter-postgres/package.json
+++ b/packages/adapter-postgres/package.json
@@ -15,7 +15,8 @@
     "./source": "./src/postgres-source.ts",
     "./sink": "./src/postgres-sink.ts",
     "./event-store": "./src/event-store/postgres-event-store.ts",
-    "./postgres-client": "./src/util/postgres-client.ts"
+    "./postgres-client": "./src/util/postgres-client.ts",
+    "./replication-repository": "./src/data-store/pg-replication-repository.ts"
   },
   "scripts": {
     "check": "tsc --noEmit"

--- a/packages/adapter-postgres/src/data-store/pg-replication-repository.ts
+++ b/packages/adapter-postgres/src/data-store/pg-replication-repository.ts
@@ -1,0 +1,158 @@
+import { getLogger } from "@rejot-dev/contract/logger";
+
+import type { PostgresClient } from "../util/postgres-client";
+import { isPostgresError, PG_DUPLICATE_OBJECT } from "../util/postgres-error-codes";
+
+const log = getLogger(import.meta.url);
+
+export interface ReplicationSlot {
+  slotName: string;
+  database: string;
+  active: boolean;
+}
+
+export interface Publication {
+  pubName: string;
+  pubAllTables: boolean;
+}
+
+export async function checkLogicalReplication(client: PostgresClient): Promise<boolean> {
+  const result = await client.query(`
+    SELECT name, setting FROM pg_settings WHERE name = 'wal_level'
+  `);
+
+  return result.rows.length > 0 && result.rows[0]["setting"] === "logical";
+}
+
+export async function getAvailableReplicationSlots(
+  client: PostgresClient,
+): Promise<ReplicationSlot[]> {
+  try {
+    const result = await client.query(
+      `
+      SELECT slot_name, database, active 
+      FROM pg_replication_slots 
+      WHERE plugin = 'pgoutput'
+      `,
+    );
+
+    return result.rows.map((row) => ({
+      slotName: row["slot_name"],
+      database: row["database"],
+      active: row["active"],
+    }));
+  } catch (error) {
+    throw new Error(`Failed to find replication slots: ${error}`);
+  }
+}
+
+export async function getAvailablePublications(client: PostgresClient): Promise<Publication[]> {
+  try {
+    const result = await client.query(`
+      SELECT pubname, puballtables
+      FROM pg_publication
+    `);
+
+    return result.rows.map((row) => ({
+      pubName: row["pubname"],
+      pubAllTables: row["puballtables"],
+    }));
+  } catch (error) {
+    throw new Error(`Failed to find publications: ${error}`);
+  }
+}
+
+export async function ensureReplicationSlot(
+  client: PostgresClient,
+  slotName: string,
+): Promise<void> {
+  // Check if slot exists
+  const slotResult = await client.query(
+    `
+    SELECT slot_name, plugin, database FROM pg_replication_slots WHERE slot_name = $1
+  `,
+    [slotName],
+  );
+
+  log.debug(`Slot result: ${JSON.stringify(slotResult.rows)}`);
+
+  if (slotResult.rows.length === 1) {
+    const { plugin, database } = slotResult.rows[0];
+
+    if (client.config.database !== database) {
+      throw new Error(
+        `Replication slot '${slotName}' exists but is for a different database: '${database}'. ` +
+          `Expected database: '${client.config.database}'. Please pick a different slot.`,
+      );
+    }
+
+    if (plugin !== "pgoutput") {
+      throw new Error(
+        `Replication slot '${slotName}' exists but is using a different plugin: ${plugin}. Expected plugin: pgoutput`,
+      );
+    }
+  }
+
+  if (slotResult.rows.length === 0) {
+    log.debug(`Creating replication slot '${slotName}'...`);
+    try {
+      await client.query(
+        `
+        SELECT pg_create_logical_replication_slot($1, 'pgoutput')
+      `,
+        [slotName],
+      );
+      log.debug(`Replication slot '${slotName}' created successfully`);
+    } catch (error) {
+      throw new Error(`Failed to create replication slot: ${error}`);
+    }
+  }
+}
+
+export async function ensurePublication(
+  client: PostgresClient,
+  publicationName: string,
+  createPublication: boolean,
+): Promise<void> {
+  // Check if publication exists
+  const pubResult = await client.query(
+    `
+    SELECT pubname, puballtables FROM pg_publication WHERE pubname = $1
+  `,
+    [publicationName],
+  );
+
+  log.debug(`Publication result: ${JSON.stringify(pubResult.rows)}`);
+
+  if (pubResult.rows.length === 1 && pubResult.rows[0]["puballtables"]) {
+    log.debug(`Publication '${publicationName}' exists FOR ALL TABLES.`);
+  } else if (pubResult.rows.length === 0) {
+    if (!createPublication) {
+      throw new Error(
+        `Publication '${publicationName}' does not exist and create-publication is set to false`,
+      );
+    }
+
+    log.debug(`Creating publication '${publicationName}'...`);
+
+    await client.query(`
+        CREATE PUBLICATION ${publicationName} FOR ALL TABLES
+      `);
+    log.debug(`Publication '${publicationName}' created successfully`);
+  } else {
+    // Ensure watermarks table is in publication
+    try {
+      await client.query(`
+        ALTER PUBLICATION ${publicationName} ADD TABLE rejot.watermarks
+      `);
+      log.debug(`Added rejot.watermarks table to publication '${publicationName}'`);
+    } catch (error) {
+      if (isPostgresError(error, PG_DUPLICATE_OBJECT)) {
+        log.debug(`ReJot watermark table already in '${publicationName}' publication`);
+      } else {
+        throw error;
+      }
+    }
+    log.debug(`Publication '${publicationName}' already exists`);
+  }
+}

--- a/packages/contract-tools/collect/vibe-collect.ts
+++ b/packages/contract-tools/collect/vibe-collect.ts
@@ -34,10 +34,6 @@ export interface IVibeCollector {
     options?: { workspaceRoot?: string },
   ): string;
   writeToManifests(results: VibeCollectedSchemas[]): Promise<MergeDiagnostic[]>;
-  formatMergeDiagnostics(
-    diagnostics: MergeDiagnostic[],
-    _options?: { workspaceRoot?: string },
-  ): string;
 }
 
 export class NoMatchingManifestError extends ReJotError {
@@ -276,55 +272,18 @@ export class VibeCollector implements IVibeCollector {
       output.push(`Manifest: ${displayPath}`);
 
       if (schemas.publicSchemas.length > 0) {
-        output.push(ManifestPrinter.printPublicSchema(schemas.publicSchemas).join("\n"));
+        output.push(ManifestPrinter.printPublicSchemasList(schemas.publicSchemas).join("\n"));
       }
 
       if (schemas.consumerSchemas.length > 0) {
-        output.push(ManifestPrinter.printConsumerSchema(schemas.consumerSchemas).join("\n"));
+        output.push(ManifestPrinter.printConsumerSchemasList(schemas.consumerSchemas).join("\n"));
       }
 
       if (schemas.diagnostics.length > 0) {
-        output.push(this.formatMergeDiagnostics(schemas.diagnostics, options));
+        output.push(ManifestMerger.formatMergeDiagnostics(schemas.diagnostics, options));
       }
 
       output.push(""); // Add a blank line between manifests
-    }
-
-    return output.join("\n");
-  }
-
-  /**
-   * Format merge diagnostics as a string
-   * @param diagnostics The diagnostics to format
-   * @param options Optional formatting options
-   * @param options.workspaceRoot If provided, paths will be normalized relative to this root
-   */
-  formatMergeDiagnostics(
-    diagnostics: MergeDiagnostic[],
-    _options?: { workspaceRoot?: string },
-  ): string {
-    if (diagnostics.length === 0) {
-      return "";
-    }
-
-    const output: string[] = ["Diagnostics:"];
-
-    for (const diagnostic of diagnostics) {
-      const prefix =
-        diagnostic.type === "error" ? "❌" : diagnostic.type === "warning" ? "⚠️" : "ℹ️";
-      const message = ManifestMerger.getDiagnosticMessage(diagnostic);
-
-      output.push(`  ${prefix} ${message}`);
-
-      // Add hint if available
-      if (diagnostic.hint?.suggestions?.length) {
-        output.push(`    Suggestions:`);
-        diagnostic.hint.suggestions.forEach((suggestion) => {
-          output.push(`      - ${suggestion}`);
-        });
-      }
-
-      output.push(""); // Add blank line between diagnostics
     }
 
     return output.join("\n");

--- a/packages/contract-tools/manifest/manifest-file-manager.mock.ts
+++ b/packages/contract-tools/manifest/manifest-file-manager.mock.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { SyncManifestSchema } from "@rejot-dev/contract/manifest";
+import type { MergedManifest } from "@rejot-dev/contract/manifest-merger";
 
 import type { InitManifestOptions } from "./manifest.fs";
 import type { IManifestFileManager } from "./manifest-file-manager";
@@ -65,7 +66,10 @@ export class MockManifestFileManager implements IManifestFileManager {
     return manifest;
   }
 
-  async mergeAndUpdateManifest(path: string, manifests: Partial<Manifest>[]): Promise<Manifest> {
+  async mergeAndUpdateManifest(
+    path: string,
+    manifests: Partial<Manifest>[],
+  ): Promise<MergedManifest> {
     const currentManifest = await this.readManifestOrGetEmpty(path);
     const mergedManifest = manifests.reduce((acc, manifest) => {
       const definedProperties = Object.fromEntries(
@@ -74,7 +78,10 @@ export class MockManifestFileManager implements IManifestFileManager {
       return { ...acc, ...definedProperties };
     }, currentManifest) as Manifest;
     await this.writeManifest(path, mergedManifest);
-    return mergedManifest;
+    return {
+      manifest: mergedManifest,
+      diagnostics: [],
+    };
   }
 
   // Helper methods for testing

--- a/packages/contract-tools/manifest/manifest-file-manager.ts
+++ b/packages/contract-tools/manifest/manifest-file-manager.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { SyncManifestSchema } from "@rejot-dev/contract/manifest";
+import type { MergedManifest } from "@rejot-dev/contract/manifest-merger";
 
 import type { InitManifestOptions } from "./manifest.fs";
 import {
@@ -20,7 +21,7 @@ export interface IManifestFileManager {
   readManifestOrGetEmpty(path: string): Promise<Manifest>;
   readManifest(path: string): Promise<Manifest | null>;
   initManifest(path: string, slug: string, options?: InitManifestOptions): Promise<Manifest>;
-  mergeAndUpdateManifest(path: string, manifests: Partial<Manifest>[]): Promise<Manifest>;
+  mergeAndUpdateManifest(path: string, manifests: Partial<Manifest>[]): Promise<MergedManifest>;
 }
 
 export class ManifestFileManager implements IManifestFileManager {
@@ -52,7 +53,10 @@ export class ManifestFileManager implements IManifestFileManager {
     return initManifest(path, slug, options);
   }
 
-  async mergeAndUpdateManifest(path: string, manifests: Partial<Manifest>[]): Promise<Manifest> {
+  async mergeAndUpdateManifest(
+    path: string,
+    manifests: Partial<Manifest>[],
+  ): Promise<MergedManifest> {
     return mergeAndUpdateManifest(path, manifests);
   }
 }

--- a/packages/contract-tools/manifest/manifest.fs.test.ts
+++ b/packages/contract-tools/manifest/manifest.fs.test.ts
@@ -99,7 +99,7 @@ test("updateManifest - merges manifests correctly", async () => {
   };
 
   // Update manifest by merging
-  const result = await mergeAndUpdateManifest(manifestPath, [additionalManifest]);
+  const { manifest: result } = await mergeAndUpdateManifest(manifestPath, [additionalManifest]);
 
   // Verify the result has both connections
   expect(result.connections).toHaveLength(2);
@@ -120,7 +120,7 @@ test("updateManifest - handles empty additional manifests", async () => {
   const baseManifest = await readManifestOrGetEmpty(manifestPath);
   const result = await mergeAndUpdateManifest(manifestPath, []);
 
-  expect(result).toEqual(baseManifest);
+  expect(result.manifest).toEqual(baseManifest);
 });
 
 test("updateManifest - newer versions take precedence", async () => {
@@ -186,7 +186,7 @@ test("updateManifest - newer versions take precedence", async () => {
   };
 
   // Update manifest
-  const result = await mergeAndUpdateManifest(manifestPath, [additionalManifest]);
+  const { manifest: result } = await mergeAndUpdateManifest(manifestPath, [additionalManifest]);
 
   // Verify the newer version was kept
   expect(result.publicSchemas).toHaveLength(1);

--- a/packages/contract-tools/manifest/manifest.fs.ts
+++ b/packages/contract-tools/manifest/manifest.fs.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 
 import { getLogger } from "@rejot-dev/contract/logger";
 import { SyncManifestSchema } from "@rejot-dev/contract/manifest";
-import { ManifestMerger } from "@rejot-dev/contract/manifest-merger";
+import { ManifestMerger, type MergedManifest } from "@rejot-dev/contract/manifest-merger";
 
 const log = getLogger(import.meta.url);
 
@@ -222,10 +222,10 @@ export async function initManifest(
 export async function mergeAndUpdateManifest(
   path: string,
   manifests: Partial<Manifest>[],
-): Promise<Manifest> {
+): Promise<MergedManifest> {
   const existingManifest = await readManifestOrGetEmpty(path);
-  const { manifest } = ManifestMerger.mergeManifests(existingManifest, manifests);
+  const { manifest, diagnostics } = ManifestMerger.mergeManifests(existingManifest, manifests);
   await writeManifest(manifest, path);
 
-  return manifest;
+  return { manifest, diagnostics };
 }

--- a/packages/contract/manifest/manifest-merger.ts
+++ b/packages/contract/manifest/manifest-merger.ts
@@ -345,4 +345,41 @@ export class ManifestMerger {
         return `Event store '${diagnostic.item.connectionSlug}' was overwritten with new configuration`;
     }
   }
+
+  /**
+   * Format merge diagnostics as a string
+   * @param diagnostics The diagnostics to format
+   * @param options Optional formatting options
+   * @param options.workspaceRoot If provided, paths will be normalized relative to this root
+   */
+  static formatMergeDiagnostics(
+    diagnostics: MergeDiagnostic[],
+    _options?: { workspaceRoot?: string },
+  ): string {
+    if (diagnostics.length === 0) {
+      return "";
+    }
+
+    const output: string[] = ["Diagnostics:"];
+
+    for (const diagnostic of diagnostics) {
+      const prefix =
+        diagnostic.type === "error" ? "❌" : diagnostic.type === "warning" ? "⚠️" : "ℹ️";
+      const message = ManifestMerger.getDiagnosticMessage(diagnostic);
+
+      output.push(`  ${prefix} ${message}`);
+
+      // Add hint if available
+      if (diagnostic.hint?.suggestions?.length) {
+        output.push(`    Suggestions:`);
+        diagnostic.hint.suggestions.forEach((suggestion) => {
+          output.push(`      - ${suggestion}`);
+        });
+      }
+
+      output.push(""); // Add blank line between diagnostics
+    }
+
+    return output.join("\n");
+  }
 }

--- a/packages/contract/manifest/verify-manifest.test.ts
+++ b/packages/contract/manifest/verify-manifest.test.ts
@@ -3,7 +3,7 @@ import { expect, test } from "bun:test";
 import { z } from "zod";
 
 import { PublicSchemaSchema, SyncManifestSchema } from "./manifest";
-import { verifyManifests } from "./verify-manifest";
+import { verifyManifests, verifyManifestsWithPaths } from "./verify-manifest";
 
 type Manifest = z.infer<typeof SyncManifestSchema>;
 
@@ -45,7 +45,7 @@ test("verifyManifests - connection reference validation", () => {
         connectionSlug: "conn1",
         config: {
           connectionType: "postgres",
-          slotName: "slot1",
+          slotName: "pub1",
           publicationName: "pub1",
         },
       },
@@ -53,7 +53,7 @@ test("verifyManifests - connection reference validation", () => {
         connectionSlug: "conn2",
         config: {
           connectionType: "postgres",
-          slotName: "slot2",
+          slotName: "pub2",
           publicationName: "pub2",
         },
       },
@@ -79,6 +79,29 @@ test("verifyManifests - connection reference validation", () => {
 test("verifyManifests - public schema reference validation", () => {
   const manifest1: Manifest = {
     ...createBasicManifest("manifest1"),
+    connections: [
+      {
+        slug: "ds1",
+        config: {
+          connectionType: "postgres",
+          host: "localhost",
+          port: 5432,
+          database: "test",
+          user: "user",
+          password: "pass",
+        },
+      },
+    ],
+    dataStores: [
+      {
+        connectionSlug: "ds1",
+        config: {
+          connectionType: "postgres",
+          slotName: "pub1",
+          publicationName: "pub1",
+        },
+      },
+    ],
     publicSchemas: [
       {
         name: "users",
@@ -103,7 +126,7 @@ test("verifyManifests - public schema reference validation", () => {
     ...createBasicManifest("manifest2"),
     consumerSchemas: [
       {
-        name: "users_consumer",
+        name: "consume-public-account",
         sourceManifestSlug: "manifest1",
         publicSchema: {
           name: "users",
@@ -118,7 +141,7 @@ test("verifyManifests - public schema reference validation", () => {
         ],
       },
       {
-        name: "products_consumer",
+        name: "consume-public-account",
         sourceManifestSlug: "manifest1",
         publicSchema: {
           name: "products", // Non-existent schema
@@ -136,6 +159,7 @@ test("verifyManifests - public schema reference validation", () => {
   };
 
   const result = verifyManifests([manifest1, manifest2]);
+
   expect(result.isValid).toBe(false);
   expect(result.errors).toHaveLength(2);
 
@@ -156,7 +180,7 @@ test("verifyManifests - non-existent source manifest", () => {
     ...createBasicManifest("test-manifest"),
     consumerSchemas: [
       {
-        name: "test_consumer",
+        name: "consume-public-account",
         sourceManifestSlug: "non-existent",
         publicSchema: {
           name: "test",
@@ -173,10 +197,18 @@ test("verifyManifests - non-existent source manifest", () => {
     ],
   };
 
+  // With checkPublicSchemaReferences = true (default), it should be invalid
   const result = verifyManifests([manifest]);
-  expect(result.isValid).toBe(true);
-  expect(result.errors).toHaveLength(0);
+  expect(result.isValid).toBe(false);
+  expect(result.errors.length).toBeGreaterThan(0);
+  expect(result.errors.some((e) => e.type === "MANIFEST_NOT_FOUND")).toBe(true);
   expect(result.externalReferences).toHaveLength(1);
+
+  // With checkPublicSchemaReferences = false, it should be valid
+  const resultWithoutCheck = verifyManifests([manifest], false);
+  expect(resultWithoutCheck.isValid).toBe(true);
+  expect(resultWithoutCheck.errors.filter((e) => e.severity === "error")).toHaveLength(0);
+  expect(resultWithoutCheck.externalReferences).toHaveLength(1);
 
   const extRef = result.externalReferences[0];
   expect(extRef.manifestSlug).toBe("non-existent");
@@ -204,15 +236,62 @@ test("verifyManifests - duplicate public schema definition", () => {
 
   const manifest1: Manifest = {
     ...createBasicManifest("manifest1"),
+    connections: [
+      {
+        slug: "ds1",
+        config: {
+          connectionType: "postgres",
+          host: "localhost",
+          port: 5432,
+          database: "test",
+          user: "user",
+          password: "pass",
+        },
+      },
+    ],
+    dataStores: [
+      {
+        connectionSlug: "ds1",
+        config: {
+          connectionType: "postgres",
+          slotName: "pub1",
+          publicationName: "pub1",
+        },
+      },
+    ],
     publicSchemas: [publicSchema],
   };
 
   const manifest2: Manifest = {
     ...createBasicManifest("manifest2"),
+    connections: [
+      {
+        slug: "ds1",
+        config: {
+          connectionType: "postgres",
+          host: "localhost",
+          port: 5432,
+          database: "test",
+          user: "user",
+          password: "pass",
+        },
+      },
+    ],
+    dataStores: [
+      {
+        connectionSlug: "ds1",
+        config: {
+          connectionType: "postgres",
+          slotName: "pub1",
+          publicationName: "pub1",
+        },
+      },
+    ],
     publicSchemas: [publicSchema],
   };
 
   const result = verifyManifests([manifest1, manifest2]);
+
   expect(result.isValid).toBe(false);
   expect(result.errors).toHaveLength(1);
   expect(result.errors[0].type).toBe("DUPLICATE_PUBLIC_SCHEMA");
@@ -225,7 +304,7 @@ test("verifyManifests - identifies multiple external references", () => {
     ...createBasicManifest("local-manifest"),
     consumerSchemas: [
       {
-        name: "schema1_consumer",
+        name: "consume-public-account",
         sourceManifestSlug: "external-manifest-1",
         publicSchema: {
           name: "schema1",
@@ -235,7 +314,7 @@ test("verifyManifests - identifies multiple external references", () => {
         transformations: [],
       },
       {
-        name: "schema2_consumer",
+        name: "consume-public-account",
         sourceManifestSlug: "external-manifest-1",
         publicSchema: {
           name: "schema2",
@@ -245,7 +324,7 @@ test("verifyManifests - identifies multiple external references", () => {
         transformations: [],
       },
       {
-        name: "schema3_consumer",
+        name: "consume-public-account",
         sourceManifestSlug: "external-manifest-2",
         publicSchema: {
           name: "schema3",
@@ -257,11 +336,19 @@ test("verifyManifests - identifies multiple external references", () => {
     ],
   };
 
-  const result = verifyManifests([manifest]);
-  expect(result.isValid).toBe(true);
-  expect(result.errors).toHaveLength(0);
+  // With checkPublicSchemaReferences = false, it should be valid with no errors
+  const resultWithoutCheck = verifyManifests([manifest], false);
+  expect(resultWithoutCheck.isValid).toBe(true);
+  expect(resultWithoutCheck.errors.filter((e) => e.severity === "error")).toHaveLength(0);
+  expect(resultWithoutCheck.externalReferences).toHaveLength(3);
 
-  // Should have three external references
+  // With checkPublicSchemaReferences = true, it should be invalid with MANIFEST_NOT_FOUND errors
+  const result = verifyManifests([manifest]);
+  expect(result.isValid).toBe(false);
+  // We get 3 MANIFEST_NOT_FOUND errors because we have 3 consumer schemas with external references
+  // Even though they reference only 2 different manifests
+  const manifestNotFoundErrors = result.errors.filter((e) => e.type === "MANIFEST_NOT_FOUND");
+  expect(manifestNotFoundErrors.length).toBe(3);
   expect(result.externalReferences).toHaveLength(3);
 
   // References should be to two different external manifests
@@ -297,12 +384,16 @@ test("verifyManifests - handles both errors and external references", () => {
     dataStores: [
       {
         connectionSlug: "conn2",
-        config: { connectionType: "postgres", slotName: "slot2", publicationName: "pub2" },
+        config: {
+          connectionType: "postgres",
+          slotName: "pub",
+          publicationName: "pub",
+        },
       }, // Invalid connection
     ],
     consumerSchemas: [
       {
-        name: "external_consumer",
+        name: "consume-public-account",
         sourceManifestSlug: "external-manifest", // External reference
         publicSchema: {
           name: "external-schema",
@@ -316,13 +407,378 @@ test("verifyManifests - handles both errors and external references", () => {
 
   const result = verifyManifests([manifest]);
 
-  // Should be invalid due to the connection error
+  // Should be invalid due to the connection error and manifest not found error
   expect(result.isValid).toBe(false);
-  expect(result.errors).toHaveLength(1);
-  expect(result.errors[0].type).toBe("CONNECTION_NOT_FOUND");
+  expect(result.errors.length).toBeGreaterThan(1);
+
+  // Check for specific error types
+  expect(result.errors.some((e) => e.type === "CONNECTION_NOT_FOUND")).toBe(true);
+  expect(result.errors.some((e) => e.type === "MANIFEST_NOT_FOUND")).toBe(true);
+  expect(result.errors.some((e) => e.type === "UNUSED_CONNECTION")).toBe(true);
 
   // But still track the external reference
   expect(result.externalReferences).toHaveLength(1);
   expect(result.externalReferences[0].manifestSlug).toBe("external-manifest");
   expect(result.externalReferences[0].publicSchema.name).toBe("external-schema");
+});
+
+test("verifyManifests - duplicate manifest slugs", () => {
+  const manifest1 = createBasicManifest("test-manifest");
+  const manifest2 = createBasicManifest("test-manifest");
+
+  const result = verifyManifests([manifest1, manifest2]);
+  expect(result.isValid).toBe(false);
+  expect(result.errors).toHaveLength(1);
+  expect(result.errors[0].type).toBe("DUPLICATE_MANIFEST_SLUG");
+  expect(result.errors[0].severity).toBe("error");
+  expect(result.errors[0].message).toContain("test-manifest");
+  expect(result.errors[0].location.manifestSlug).toBe("test-manifest");
+});
+
+test("verifyManifestsWithPaths - enhances diagnostics with file paths", () => {
+  const manifest = createBasicManifest("test-manifest");
+  manifest.connections = [
+    {
+      slug: "conn1",
+      config: {
+        connectionType: "postgres",
+        host: "localhost",
+        port: 5432,
+        database: "test",
+        user: "user",
+        password: "pass",
+      },
+    },
+  ];
+  manifest.dataStores = [
+    {
+      connectionSlug: "conn2", // Non-existent connection
+      config: {
+        connectionType: "postgres",
+        slotName: "pub",
+        publicationName: "pub",
+      },
+    },
+  ];
+
+  const manifestWithPath = {
+    manifest,
+    path: "/path/to/manifest.json",
+  };
+
+  const result = verifyManifestsWithPaths([manifestWithPath]);
+  expect(result.isValid).toBe(false);
+  expect(result.errors).toHaveLength(2); // CONNECTION_NOT_FOUND and UNUSED_CONNECTION
+
+  // Check that all errors have the manifestPath
+  result.errors.forEach((error) => {
+    expect(error.location.manifestPath).toBe("/path/to/manifest.json");
+  });
+});
+
+test("verifyManifests - connection type mismatch validation", () => {
+  const manifest: Manifest = {
+    ...createBasicManifest("test-manifest"),
+    connections: [
+      {
+        slug: "conn1",
+        config: {
+          connectionType: "postgres",
+          host: "localhost",
+          port: 5432,
+          database: "test",
+          user: "user",
+          password: "pass",
+        },
+      },
+      {
+        slug: "conn2",
+        config: {
+          connectionType: "in-memory",
+        },
+      },
+    ],
+    dataStores: [
+      {
+        connectionSlug: "conn1",
+        config: {
+          connectionType: "postgres", // This matches - no error
+          slotName: "pub1",
+          publicationName: "pub1",
+        },
+      },
+      {
+        connectionSlug: "conn2",
+        config: {
+          connectionType: "postgres", // Mismatch - should error
+          slotName: "pub2",
+          publicationName: "pub2",
+        },
+      },
+    ],
+  };
+
+  const result = verifyManifests([manifest]);
+  expect(result.isValid).toBe(false);
+
+  // Find the connection type mismatch error
+  const typeMismatchError = result.errors.find((e) => e.type === "CONNECTION_TYPE_MISMATCH");
+  expect(typeMismatchError).toBeDefined();
+  expect(typeMismatchError?.message).toContain(
+    "'postgres' but references connection 'conn2' with type 'in-memory'",
+  );
+  expect(typeMismatchError?.severity).toBe("error");
+});
+
+test("verifyManifests - public schema source data store validation", () => {
+  const manifest: Manifest = {
+    ...createBasicManifest("test-manifest"),
+    dataStores: [
+      {
+        connectionSlug: "existing-store",
+        config: {
+          connectionType: "postgres",
+          slotName: "pub1",
+          publicationName: "pub1",
+        },
+      },
+    ],
+    publicSchemas: [
+      {
+        name: "valid-schema",
+        source: {
+          dataStoreSlug: "existing-store", // This exists - no error
+          tables: ["users"],
+        },
+        outputSchema: { type: "object", properties: {} },
+        transformations: [
+          {
+            transformationType: "postgresql",
+            table: "users",
+            sql: "SELECT * FROM users",
+          },
+        ],
+        version: { major: 1, minor: 0 },
+      },
+      {
+        name: "invalid-schema",
+        source: {
+          dataStoreSlug: "non-existent-store", // This doesn't exist - should error
+          tables: ["users"],
+        },
+        outputSchema: { type: "object", properties: {} },
+        transformations: [
+          {
+            transformationType: "postgresql",
+            table: "users",
+            sql: "SELECT * FROM users",
+          },
+        ],
+        version: { major: 1, minor: 0 },
+      },
+    ],
+  };
+
+  const result = verifyManifests([manifest]);
+  expect(result.isValid).toBe(false);
+
+  // Find the data store not found error
+  const dataStoreError = result.errors.find(
+    (e) => e.type === "DATA_STORE_NOT_FOUND" && e.message.includes("non-existent-store"),
+  );
+  expect(dataStoreError).toBeDefined();
+  expect(dataStoreError?.message).toContain("invalid-schema");
+  expect(dataStoreError?.message).toContain("non-existent-store");
+  expect(dataStoreError?.severity).toBe("error");
+  expect(dataStoreError?.location.context).toContain("publicSchemas");
+});
+
+test("verifyManifests - consumer schema destination data store validation", () => {
+  const manifest1: Manifest = {
+    ...createBasicManifest("manifest1"),
+    connections: [
+      {
+        slug: "conn1",
+        config: {
+          connectionType: "postgres",
+          host: "localhost",
+          port: 5432,
+          database: "test",
+          user: "user",
+          password: "pass",
+        },
+      },
+    ],
+    dataStores: [
+      {
+        connectionSlug: "conn1",
+        config: {
+          connectionType: "postgres",
+          slotName: "pub1",
+          publicationName: "pub1",
+        },
+      },
+    ],
+    publicSchemas: [
+      {
+        name: "users",
+        source: {
+          dataStoreSlug: "conn1",
+          tables: ["users"],
+        },
+        outputSchema: { type: "object", properties: {} },
+        transformations: [
+          {
+            transformationType: "postgresql",
+            table: "users",
+            sql: "SELECT * FROM users",
+          },
+        ],
+        version: { major: 1, minor: 0 },
+      },
+    ],
+  };
+
+  const manifest2: Manifest = {
+    ...createBasicManifest("manifest2"),
+    connections: [
+      {
+        slug: "conn2",
+        config: {
+          connectionType: "postgres",
+          host: "localhost",
+          port: 5432,
+          database: "test",
+          user: "user",
+          password: "pass",
+        },
+      },
+    ],
+    dataStores: [
+      {
+        connectionSlug: "conn2",
+        config: {
+          connectionType: "postgres",
+          slotName: "pub2",
+          publicationName: "pub2",
+        },
+      },
+    ],
+    consumerSchemas: [
+      {
+        name: "valid-consumer",
+        sourceManifestSlug: "manifest1",
+        publicSchema: {
+          name: "users",
+          majorVersion: 1,
+        },
+        destinationDataStoreSlug: "conn2", // This exists - no error
+        transformations: [
+          {
+            transformationType: "postgresql",
+            sql: "INSERT INTO users SELECT * FROM source_users",
+          },
+        ],
+      },
+      {
+        name: "invalid-consumer",
+        sourceManifestSlug: "manifest1",
+        publicSchema: {
+          name: "users",
+          majorVersion: 1,
+        },
+        destinationDataStoreSlug: "non-existent-store", // This doesn't exist - should error
+        transformations: [
+          {
+            transformationType: "postgresql",
+            sql: "INSERT INTO users SELECT * FROM source_users",
+          },
+        ],
+      },
+    ],
+  };
+
+  const result = verifyManifests([manifest1, manifest2]);
+  expect(result.isValid).toBe(false);
+
+  // Find the data store not found error
+  const dataStoreError = result.errors.find(
+    (e) => e.type === "DATA_STORE_NOT_FOUND" && e.message.includes("non-existent-store"),
+  );
+  expect(dataStoreError).toBeDefined();
+  expect(dataStoreError?.message).toContain("non-existent-store");
+  expect(dataStoreError?.message).toContain("manifest1");
+  expect(dataStoreError?.severity).toBe("error");
+  expect(dataStoreError?.location.context).toContain("destinationDataStoreSlug");
+});
+
+test("verifyManifests - undefined source manifest slug", () => {
+  const manifest: Manifest = {
+    slug: "@rejot/",
+    manifestVersion: 0,
+    consumerSchemas: [
+      {
+        name: "consume-public-account",
+        sourceManifestSlug: "default",
+        publicSchema: {
+          name: "public-account",
+          majorVersion: 1,
+        },
+        destinationDataStoreSlug: "data-destination-1",
+        transformations: [
+          {
+            transformationType: "postgresql",
+            sql: "\n        INSERT INTO users_destination \n          (id, full_name)\n        VALUES \n          (:id, :email || ' ' || :name)\n        ON CONFLICT (id) DO UPDATE\n          SET full_name = :email || ' ' || :name\n        ;\n      ",
+          },
+        ],
+        definitionFile: "apps/rejot-cli/_test/example-schema.ts",
+      },
+    ],
+  };
+
+  const result = verifyManifests([manifest]);
+  expect(result.isValid).toBe(false);
+
+  // Check that we have MANIFEST_NOT_FOUND error
+  const manifestNotFoundError = result.errors.find((e) => e.type === "MANIFEST_NOT_FOUND");
+  expect(manifestNotFoundError).toBeDefined();
+  expect(manifestNotFoundError?.message).toContain("default");
+  expect(manifestNotFoundError?.severity).toBe("error");
+});
+
+test("verifyManifests - undefined source manifest slug with checkPublicSchemaReferences=false", () => {
+  const manifest: Manifest = {
+    slug: "@rejot/",
+    manifestVersion: 0,
+    consumerSchemas: [
+      {
+        name: "consume-public-account",
+        sourceManifestSlug: "default",
+        publicSchema: {
+          name: "public-account",
+          majorVersion: 1,
+        },
+        destinationDataStoreSlug: "data-destination-1",
+        transformations: [
+          {
+            transformationType: "postgresql",
+            sql: "\n        INSERT INTO users_destination \n          (id, full_name)\n        VALUES \n          (:id, :email || ' ' || :name)\n        ON CONFLICT (id) DO UPDATE\n          SET full_name = :email || ' ' || :name\n        ;\n      ",
+          },
+        ],
+        definitionFile: "apps/rejot-cli/_test/example-schema.ts",
+      },
+    ],
+  };
+
+  // With checkPublicSchemaReferences = false, it should be valid
+  const result = verifyManifests([manifest], false);
+  expect(result.isValid).toBe(true);
+
+  expect(result.errors).toHaveLength(0);
+
+  // Should still track the external reference
+  expect(result.externalReferences).toHaveLength(1);
+  expect(result.externalReferences[0].manifestSlug).toBe("default");
+  expect(result.externalReferences[0].publicSchema.name).toBe("public-account");
+  expect(result.externalReferences[0].publicSchema.majorVersion).toBe(1);
 });

--- a/packages/contract/manifest/verify-manifest.ts
+++ b/packages/contract/manifest/verify-manifest.ts
@@ -1,16 +1,27 @@
 import { z } from "zod";
 
+import type { ManifestWithPath } from "../workspace/workspace";
 import { SyncManifestSchema } from "./manifest";
+
+export type ManifestDiagnosticSeverity = "error" | "warning";
 
 export type ManifestDiagnostic = {
   type:
     | "CONNECTION_NOT_FOUND"
     | "PUBLIC_SCHEMA_NOT_FOUND"
     | "VERSION_MISMATCH"
-    | "DUPLICATE_PUBLIC_SCHEMA";
+    | "DUPLICATE_PUBLIC_SCHEMA"
+    | "UNUSED_CONNECTION"
+    | "DATA_STORE_NOT_FOUND"
+    | "DUPLICATE_MANIFEST_SLUG"
+    | "CONNECTION_TYPE_MISMATCH"
+    | "MANIFEST_NOT_FOUND";
+
+  severity: ManifestDiagnosticSeverity;
   message: string;
   location: {
     manifestSlug: string;
+    manifestPath?: string;
     context?: string;
   };
   hint?: {
@@ -39,9 +50,39 @@ export type VerificationResult = {
 };
 
 /**
+ * Verifies that all manifest slugs are unique
+ */
+function verifyManifestSlugUniqueness(
+  manifests: z.infer<typeof SyncManifestSchema>[],
+): ManifestDiagnostic[] {
+  const errors: ManifestDiagnostic[] = [];
+  const slugMap = new Map<string, z.infer<typeof SyncManifestSchema>>();
+
+  manifests.forEach((manifest) => {
+    if (slugMap.has(manifest.slug)) {
+      errors.push({
+        type: "DUPLICATE_MANIFEST_SLUG",
+        severity: "error",
+        message: `Manifest slug '${manifest.slug}' is already used by another manifest`,
+        location: {
+          manifestSlug: manifest.slug,
+        },
+        hint: {
+          message: "Each manifest must have a unique slug",
+          suggestions: "Change the slug of one of the manifests",
+        },
+      });
+    }
+    slugMap.set(manifest.slug, manifest);
+  });
+
+  return errors;
+}
+
+/**
  * Verifies that all connections referenced by dataStores and eventStores exist within the manifest
  */
-export function verifyConnectionReferences(
+function verifyConnectionReferences(
   manifest: z.infer<typeof SyncManifestSchema>,
 ): ManifestDiagnostic[] {
   const errors: ManifestDiagnostic[] = [];
@@ -49,11 +90,18 @@ export function verifyConnectionReferences(
   // Get all connection slugs
   const connectionSlugs = new Set((manifest.connections ?? []).map((c) => c.slug));
 
+  // Create a map of connection slugs to their connection types for validation
+  const connectionTypeMap = new Map<string, string>();
+  (manifest.connections ?? []).forEach((connection) => {
+    connectionTypeMap.set(connection.slug, connection.config.connectionType);
+  });
+
   // Check data store references
   (manifest.dataStores ?? []).forEach((ds) => {
     if (!connectionSlugs.has(ds.connectionSlug)) {
       errors.push({
         type: "CONNECTION_NOT_FOUND",
+        severity: "error",
         message: `Data store references connection '${ds.connectionSlug}' which does not exist`,
         location: {
           manifestSlug: manifest.slug,
@@ -64,6 +112,27 @@ export function verifyConnectionReferences(
           suggestions: `Use 'rejot manifest connection add --slug ${ds.connectionSlug}' to add the connection`,
         },
       });
+    } else {
+      // Check if the connection type matches the data store config's connection type
+      const connectionType = connectionTypeMap.get(ds.connectionSlug);
+      const dataStoreConnectionType = ds.config.connectionType;
+
+      if (connectionType !== dataStoreConnectionType) {
+        errors.push({
+          type: "CONNECTION_TYPE_MISMATCH",
+          severity: "error",
+          message: `Data store config has connection type '${dataStoreConnectionType}' but references connection '${ds.connectionSlug}' with type '${connectionType}'`,
+          location: {
+            manifestSlug: manifest.slug,
+            context: `dataStore.connectionSlug: ${ds.connectionSlug}`,
+          },
+          hint: {
+            message:
+              "Ensure the data store config connection type matches the referenced connection type",
+            suggestions: `Change the data store config connection type to '${connectionType}' or use a connection with matching type`,
+          },
+        });
+      }
     }
   });
 
@@ -72,6 +141,7 @@ export function verifyConnectionReferences(
     if (!connectionSlugs.has(es.connectionSlug)) {
       errors.push({
         type: "CONNECTION_NOT_FOUND",
+        severity: "error",
         message: `Event store references connection '${es.connectionSlug}' which does not exist`,
         location: {
           manifestSlug: manifest.slug,
@@ -85,6 +155,28 @@ export function verifyConnectionReferences(
     }
   });
 
+  // Check for unused connections
+  (manifest.connections ?? []).forEach((connection) => {
+    const isUsed = [...(manifest.dataStores ?? []), ...(manifest.eventStores ?? [])].some(
+      (store) => store.connectionSlug === connection.slug,
+    );
+    if (!isUsed) {
+      errors.push({
+        type: "UNUSED_CONNECTION",
+        severity: "warning",
+        message: `Connection '${connection.slug}' is not used by any data store or event store`,
+        location: {
+          manifestSlug: manifest.slug,
+          context: `connection.slug: ${connection.slug}`,
+        },
+        hint: {
+          message: "Consider removing unused connections to keep the manifest clean",
+          suggestions: `Use 'rejot manifest connection remove --slug ${connection.slug}' to remove the connection`,
+        },
+      });
+    }
+  });
+
   return errors;
 }
 
@@ -93,17 +185,26 @@ export function verifyConnectionReferences(
  * Identifies references to manifests not included in the set.
  * Returns both validation errors and identified external references.
  */
-export function verifyPublicSchemaReferences(manifests: z.infer<typeof SyncManifestSchema>[]): {
+export function verifyPublicSchemaReferences(
+  manifests: ManifestWithPath[],
+  checkExternalReferences: boolean = false,
+): {
   errors: ManifestDiagnostic[];
   externalReferences: ExternalPublicSchemaReference[];
 } {
   const errors: ManifestDiagnostic[] = [];
   const unresolvedExternalReferences: ExternalPublicSchemaReference[] = [];
 
+  // Build a map of all available manifests for quick lookup
+  const manifestMap = new Map<string, ManifestWithPath>();
+  manifests.forEach((manifestWithPath) => {
+    manifestMap.set(manifestWithPath.manifest.slug, manifestWithPath);
+  });
+
   // Build a map of all available public schemas across all manifests
   const publicSchemaMap = new Map<string, Map<string, number[]>>();
-  manifests.forEach((manifest) => {
-    (manifest.publicSchemas ?? []).forEach((schema) => {
+  manifests.forEach(({ manifest }) => {
+    manifest.publicSchemas?.forEach((schema) => {
       if (!publicSchemaMap.has(manifest.slug)) {
         publicSchemaMap.set(manifest.slug, new Map());
       }
@@ -115,14 +216,58 @@ export function verifyPublicSchemaReferences(manifests: z.infer<typeof SyncManif
     });
   });
 
+  // Build a map of all data stores
+  const dataStoreMap = new Map<string, Set<string>>();
+  manifests.forEach(({ manifest }) => {
+    const storeNames = new Set(manifest.dataStores?.map((ds) => ds.connectionSlug) ?? []);
+    dataStoreMap.set(manifest.slug, storeNames);
+  });
+
+  // Verify public schemas reference valid data stores
+  manifests.forEach(({ manifest, path: manifestPath }) => {
+    manifest.publicSchemas?.forEach((publicSchema, index) => {
+      const manifestDataStores = dataStoreMap.get(manifest.slug);
+      if (manifestDataStores && !manifestDataStores.has(publicSchema.source.dataStoreSlug)) {
+        errors.push({
+          type: "DATA_STORE_NOT_FOUND",
+          severity: "error",
+          message: `Public schema '${publicSchema.name}' references data store '${publicSchema.source.dataStoreSlug}' which does not exist in manifest '${manifest.slug}'`,
+          location: {
+            manifestSlug: manifest.slug,
+            manifestPath,
+            context: `publicSchemas[${index}].source.dataStoreSlug: ${publicSchema.source.dataStoreSlug}`,
+          },
+        });
+      }
+    });
+  });
+
   // Verify consumer schema references
-  manifests.forEach((manifest) => {
-    (manifest.consumerSchemas ?? []).forEach((consumerSchema) => {
+  manifests.forEach(({ manifest, path: manifestPath }) => {
+    manifest.consumerSchemas?.forEach((consumerSchema) => {
+      const sourceManifestWithPath = manifestMap.get(consumerSchema.sourceManifestSlug);
       const sourceManifestSchemas = publicSchemaMap.get(consumerSchema.sourceManifestSlug);
 
-      if (!sourceManifestSchemas) {
+      if (!sourceManifestWithPath) {
         // This references an external manifest not included in the verification set.
-        // Record it as an external reference instead of erroring or skipping.
+        if (checkExternalReferences) {
+          // If we're checking external references, report it as an error
+          errors.push({
+            type: "MANIFEST_NOT_FOUND",
+            severity: "error",
+            message: `Consumer schema '${consumerSchema.name}' references manifest '${consumerSchema.sourceManifestSlug}' which does not exist in the workspace`,
+            location: {
+              manifestSlug: manifest.slug,
+              manifestPath,
+              context: `consumerSchema.sourceManifestSlug: ${consumerSchema.sourceManifestSlug}`,
+            },
+            hint: {
+              message: "Ensure all referenced manifests are included in the workspace",
+            },
+          });
+        }
+
+        // Record it as an external reference
         unresolvedExternalReferences.push({
           manifestSlug: consumerSchema.sourceManifestSlug,
           publicSchema: {
@@ -136,13 +281,15 @@ export function verifyPublicSchemaReferences(manifests: z.infer<typeof SyncManif
         return; // Continue to the next consumer schema
       }
 
-      const availableVersions = sourceManifestSchemas.get(consumerSchema.publicSchema.name);
+      const availableVersions = sourceManifestSchemas?.get(consumerSchema.publicSchema.name);
       if (!availableVersions) {
         errors.push({
           type: "PUBLIC_SCHEMA_NOT_FOUND",
+          severity: "error",
           message: `Consumer schema references public schema '${consumerSchema.publicSchema.name}' which does not exist in manifest '${consumerSchema.sourceManifestSlug}'`,
           location: {
             manifestSlug: manifest.slug,
+            manifestPath,
             context: `consumerSchema.publicSchema.name: ${consumerSchema.publicSchema.name}`,
           },
         });
@@ -153,45 +300,62 @@ export function verifyPublicSchemaReferences(manifests: z.infer<typeof SyncManif
       if (!availableVersions.includes(consumerSchema.publicSchema.majorVersion)) {
         errors.push({
           type: "VERSION_MISMATCH",
+          severity: "error",
           message: `Consumer schema requires version ${consumerSchema.publicSchema.majorVersion} of public schema '${consumerSchema.publicSchema.name}', but available versions are: ${availableVersions.join(", ")}`,
           location: {
             manifestSlug: manifest.slug,
+            manifestPath,
             context: `consumerSchema.publicSchema (name: ${consumerSchema.publicSchema.name}, version: ${consumerSchema.publicSchema.majorVersion})`,
+          },
+        });
+      }
+
+      // Check if referenced data store exists
+      const sourceManifestStores = dataStoreMap.get(consumerSchema.sourceManifestSlug);
+      if (!sourceManifestStores?.has(consumerSchema.destinationDataStoreSlug)) {
+        errors.push({
+          type: "DATA_STORE_NOT_FOUND",
+          severity: "error",
+          message: `Consumer schema references data store '${consumerSchema.destinationDataStoreSlug}' which does not exist in manifest '${consumerSchema.sourceManifestSlug}'`,
+          location: {
+            manifestSlug: manifest.slug,
+            manifestPath,
+            context: `consumerSchema.destinationDataStoreSlug: ${consumerSchema.destinationDataStoreSlug}`,
           },
         });
       }
     });
   });
 
-  return { errors, externalReferences: unresolvedExternalReferences }; // Return both errors and external references
+  return { errors, externalReferences: unresolvedExternalReferences };
 }
 
 /**
  * Verifies that all public schemas referenced by consumer schemas exist and version compatibility
  */
-export function verifyPublicSchemaUniqueness(
-  manifests: z.infer<typeof SyncManifestSchema>[],
-): ManifestDiagnostic[] {
+export function verifyPublicSchemaUniqueness(manifests: ManifestWithPath[]): ManifestDiagnostic[] {
   const errors: ManifestDiagnostic[] = [];
 
   // Build a map of public schemas & version to manifest slug
-  const publicSchemaMapManifest = new Map<string, string>();
+  const publicSchemaMapManifest = new Map<string, { slug: string; path: string }>();
 
-  manifests.forEach((manifest) => {
-    (manifest.publicSchemas ?? []).forEach((schema, index) => {
+  manifests.forEach(({ manifest, path: manifestPath }) => {
+    manifest.publicSchemas?.forEach((schema, index) => {
       const key = `${schema.name}:${schema.version.major}.${schema.version.minor}`;
-      const previousManifest = publicSchemaMapManifest.get(key);
-      if (previousManifest) {
+      const previous = publicSchemaMapManifest.get(key);
+      if (previous) {
         errors.push({
           type: "DUPLICATE_PUBLIC_SCHEMA",
-          message: `Public schema '${schema.name}' version ${schema.version.major}.${schema.version.minor} already defined in manifest '${previousManifest}'`,
+          severity: "error",
+          message: `Public schema '${schema.name}' version ${schema.version.major}.${schema.version.minor} already defined in manifest '${previous.slug}'`,
           location: {
             manifestSlug: manifest.slug,
+            manifestPath,
             context: `publicSchemas[${index}] (name: ${schema.name}, version: ${schema.version.major}.${schema.version.minor})`,
           },
         });
       }
-      publicSchemaMapManifest.set(key, manifest.slug);
+      publicSchemaMapManifest.set(key, { slug: manifest.slug, path: manifestPath });
     });
   });
 
@@ -207,24 +371,70 @@ export function verifyManifests(
 ): VerificationResult {
   const errors: ManifestDiagnostic[] = [];
 
+  // Check for duplicate manifest slugs
+  errors.push(...verifyManifestSlugUniqueness(manifests));
+
   // Verify each individual manifest
   manifests.forEach((manifest) => {
     // Verify internal connection references
     errors.push(...verifyConnectionReferences(manifest));
   });
 
-  const publicSchemaReferencesResult = verifyPublicSchemaReferences(manifests);
+  // Convert manifests to ManifestWithPath format for cross-manifest checks
+  const manifestsWithPath = manifests.map((manifest) => ({
+    manifest,
+    path: "",
+  }));
+
+  const publicSchemaReferencesResult = verifyPublicSchemaReferences(
+    manifestsWithPath,
+    checkPublicSchemaReferences,
+  );
 
   // Verify cross-manifest references
   if (checkPublicSchemaReferences) {
     errors.push(...publicSchemaReferencesResult.errors);
   }
 
-  errors.push(...verifyPublicSchemaUniqueness(manifests));
+  errors.push(...verifyPublicSchemaUniqueness(manifestsWithPath));
 
   return {
-    isValid: errors.length === 0, // Validity depends only on errors, not external references
+    isValid: errors.filter((e) => e.severity === "error").length === 0, // Only errors affect validity, not warnings
     errors,
     externalReferences: publicSchemaReferencesResult.externalReferences,
+  };
+}
+
+/**
+ * Enhances diagnostics with file paths for workspace verification
+ */
+export function verifyManifestsWithPaths(
+  manifests: ManifestWithPath[],
+  checkPublicSchemaReferences = true,
+): VerificationResult {
+  // First verify the manifests without paths
+  const baseResult = verifyManifests(
+    manifests.map((m) => m.manifest),
+    checkPublicSchemaReferences,
+  );
+
+  // Enhance the diagnostics with file paths
+  const enhancedErrors = baseResult.errors.map((error) => {
+    const manifest = manifests.find((m) => m.manifest.slug === error.location.manifestSlug);
+    if (manifest) {
+      return {
+        ...error,
+        location: {
+          ...error.location,
+          manifestPath: manifest.path,
+        },
+      };
+    }
+    return error;
+  });
+
+  return {
+    ...baseResult,
+    errors: enhancedErrors,
   };
 }

--- a/packages/contract/workspace/workspace.ts
+++ b/packages/contract/workspace/workspace.ts
@@ -1,6 +1,7 @@
 import type { z } from "zod";
 
 import type { SyncManifestSchema } from "../manifest/manifest";
+import { type VerificationResult, verifyManifestsWithPaths } from "../manifest/verify-manifest";
 
 export interface ManifestWithPath {
   /** Path is relative to the rootPath in the workspace. */
@@ -13,4 +14,22 @@ export interface WorkspaceDefinition {
   rootPath: string;
   ancestor: ManifestWithPath;
   children: ManifestWithPath[];
+}
+
+/**
+ * Verifies a workspace by checking all manifests within it.
+ * This includes the ancestor manifest and all child manifests.
+ *
+ * @param workspace The workspace to verify
+ * @param checkPublicSchemaReferences Whether to verify public schema references across manifests
+ * @returns A VerificationResult containing any errors, warnings, and external references
+ */
+export function verifyWorkspace(
+  workspace: WorkspaceDefinition,
+  checkPublicSchemaReferences = true,
+): VerificationResult {
+  // Combine ancestor and children into a single array for verification
+  const allManifests = [workspace.ancestor, ...workspace.children];
+
+  return verifyManifestsWithPaths(allManifests, checkPublicSchemaReferences);
 }

--- a/packages/sync/src/sync-controller/public-schema-transformer.test.ts
+++ b/packages/sync/src/sync-controller/public-schema-transformer.test.ts
@@ -60,8 +60,8 @@ describe("PublicSchemaTransformer", () => {
             connectionSlug: "test-connection",
             config: {
               connectionType: "postgres" as const,
-              slotName: "test-slot",
               publicationName: "test-publication",
+              slotName: "test-slot",
             },
           },
         ],

--- a/packages/sync/src/sync-controller/sink-writer.test.ts
+++ b/packages/sync/src/sync-controller/sink-writer.test.ts
@@ -30,8 +30,6 @@ describe("SinkWriter", () => {
     connectionType: "postgres";
     slotName: string;
     publicationName: string;
-    tables?: string[];
-    allTables?: boolean;
   };
 
   // Mock PostgreSQL sink
@@ -113,9 +111,9 @@ describe("SinkWriter", () => {
           {
             connectionSlug: "test-connection",
             config: {
-              connectionType: "postgres",
-              slotName: "test-slot",
+              connectionType: "postgres" as const,
               publicationName: "test-publication",
+              slotName: "test-slot",
             },
           },
         ],
@@ -150,7 +148,7 @@ describe("SinkWriter", () => {
         ],
         consumerSchemas: [
           {
-            name: "test-consumer",
+            name: "test-consumer-schema",
             sourceManifestSlug: "test-manifest",
             publicSchema: {
               name: "test-schema",

--- a/packages/sync/src/sync-controller/source-reader.test.ts
+++ b/packages/sync/src/sync-controller/source-reader.test.ts
@@ -63,8 +63,8 @@ describe("SourceReader", () => {
             connectionSlug: "test-connection",
             config: {
               connectionType: "postgres" as const,
-              slotName: "test-slot",
               publicationName: "test-publication",
+              slotName: "test-slot",
             },
           },
         ],


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Added new tools and commands for working with public and consumer schemas, improved manifest diagnostics, and enhanced workspace verification.

- **New Features**
  - Added `SchemasTool` for finding and printing public schemas in the workspace.
  - Added `ManifestPostgresDataStoreTool` for managing Postgres data stores and replication.
  - Introduced `workspace:info` CLI command to show workspace configuration and diagnostics.

- **Improvements**
  - Expanded manifest diagnostics and verification with clearer error messages and schema summaries.
  - Refactored manifest merging and diagnostics formatting for better clarity.
  - Updated tests and internal types to support new manifest and schema features.

<!-- End of auto-generated description by mrge. -->

