### PR TITLE
Contract: publish as javascript \w types

### DIFF
--- a/apps/controller-spa/tsconfig.json
+++ b/apps/controller-spa/tsconfig.json
@@ -10,7 +10,9 @@
     "isolatedModules": true,
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "rewriteRelativeImportExtensions": false,
+    "emitDeclarationOnly": true
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["dist", "node_modules", "eslint.config.js"],

--- a/apps/controller/tsconfig.json
+++ b/apps/controller/tsconfig.json
@@ -6,7 +6,9 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "rewriteRelativeImportExtensions": false,
+    "emitDeclarationOnly": true
   },
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["dist"],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -37,6 +37,7 @@ export default tseslint.config(
     rules: {
       // ...unicornFixableRules,
       "local/require-local-package-deps": "error",
+      "local/disallow-package-name-imports": "warn",
       "@typescript-eslint/no-unused-vars": [
         "error",
         {

--- a/packages/contract/adapter/adapter.ts
+++ b/packages/contract/adapter/adapter.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { type Cursor } from "../cursor/cursors";
+import { type Cursor } from "../cursor/cursors.ts";
 import type { IEventStore, TransformedOperationWithSource } from "../event-store/event-store.ts";
 import {
   ConnectionConfigSchema,

--- a/packages/contract/collect/collect.test.ts
+++ b/packages/contract/collect/collect.test.ts
@@ -4,7 +4,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { SchemaCollector } from "./collect";
+import { SchemaCollector } from "./collect.ts";
 
 describe("collect", () => {
   let tmpDir: string;

--- a/packages/contract/cursor/cursors.ts
+++ b/packages/contract/cursor/cursors.ts
@@ -1,4 +1,4 @@
-import type { OperationMessage } from "../message-bus/message-bus";
+import type { OperationMessage } from "../message-bus/message-bus.ts";
 
 export interface PublicSchemaReference {
   manifest: {

--- a/packages/contract/event-store/event-store-message-bus.ts
+++ b/packages/contract/event-store/event-store-message-bus.ts
@@ -1,7 +1,7 @@
-import { type Cursor, Cursors } from "../cursor/cursors";
-import { getLogger } from "../logger/logger";
-import type { IMessageBus, OperationMessage } from "../message-bus/message-bus";
-import type { IEventStore } from "./event-store";
+import { type Cursor, Cursors } from "../cursor/cursors.ts";
+import { getLogger } from "../logger/logger.ts";
+import type { IMessageBus, OperationMessage } from "../message-bus/message-bus.ts";
+import type { IEventStore } from "./event-store.ts";
 
 const State = {
   INITIAL: 1,

--- a/packages/contract/event-store/event-store.ts
+++ b/packages/contract/event-store/event-store.ts
@@ -1,5 +1,5 @@
-import type { Cursor, PublicSchemaReference } from "../cursor/cursors";
-import type { OperationMessage } from "../message-bus/message-bus";
+import type { Cursor, PublicSchemaReference } from "../cursor/cursors.ts";
+import type { OperationMessage } from "../message-bus/message-bus.ts";
 
 interface TransformedOperationWithSourceBase {
   type: "insert" | "update" | "delete";

--- a/packages/contract/json-schema/json-schema-printer.ts
+++ b/packages/contract/json-schema/json-schema-printer.ts
@@ -1,4 +1,4 @@
-import { type JsonSchema } from "./json-schema";
+import { type JsonSchema } from "./json-schema.ts";
 
 export class JsonSchemaPrinter {
   static printJsonSchema(schema: JsonSchema, indentLevel: number = 1): string[] {

--- a/packages/contract/json-schema/json-schema-utils.ts
+++ b/packages/contract/json-schema/json-schema-utils.ts
@@ -1,4 +1,4 @@
-import { type JsonSchema } from "./json-schema";
+import { type JsonSchema } from "./json-schema.ts";
 
 /**
  * Validates that a JSON schema is an object and extracts all its keys

--- a/packages/contract/json-schema/json-schema.test.ts
+++ b/packages/contract/json-schema/json-schema.test.ts
@@ -4,9 +4,9 @@ import { readFile } from "node:fs/promises";
 
 import type { JsonSchema7Type } from "zod-to-json-schema";
 
-import type { JsonSchema } from "./json-schema";
-import { JsonSchemaSchema } from "./json-schema";
-import { extractSchemaKeys } from "./json-schema-utils";
+import type { JsonSchema } from "./json-schema.ts";
+import { JsonSchemaSchema } from "./json-schema.ts";
+import { extractSchemaKeys } from "./json-schema-utils.ts";
 
 type JsonSchemaFromLib = JsonSchema7Type & {
   $schema?: string;

--- a/packages/contract/json-schema/json-schema.ts
+++ b/packages/contract/json-schema/json-schema.ts
@@ -257,5 +257,5 @@ export const JsonSchemaSchema = JsonSchemaMeta.extend({
 
 export type JsonSchema = z.infer<typeof JsonSchemaSchema>;
 
-export * from "./json-schema-utils";
-export * from "./json-schema-printer";
+export * from "./json-schema-printer.ts";
+export * from "./json-schema-utils.ts";

--- a/packages/contract/logger/logger.test.ts
+++ b/packages/contract/logger/logger.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 
-import { ILogger, LogLevel, NamespacedLogger, shouldLog } from "./logger";
+import { ILogger, LogLevel, NamespacedLogger, shouldLog } from "./logger.ts";
 
 class MockLogger extends ILogger {
   public messages: { type: LogLevel; message: string; args: unknown[] }[] = [];

--- a/packages/contract/manifest-jsonschema.ts
+++ b/packages/contract/manifest-jsonschema.ts
@@ -1,5 +1,6 @@
 import { zodToJsonSchema } from "zod-to-json-schema";
-import { SyncManifestSchema } from "@rejot-dev/contract/manifest";
+
+import { SyncManifestSchema } from "./manifest/manifest.ts";
 
 const SyncManifestJsonSchema = zodToJsonSchema(SyncManifestSchema);
 

--- a/packages/contract/manifest/manifest-helpers.ts
+++ b/packages/contract/manifest/manifest-helpers.ts
@@ -1,10 +1,14 @@
 import { z } from "zod";
 
-import type { TransformedOperationWithSource } from "@rejot-dev/contract/event-store";
-import type { WorkspaceDefinition } from "@rejot-dev/contract/workspace";
-
-import type { ConsumerSchemaSchema, PublicSchemaSchema, SyncManifestSchema } from "./manifest";
-import type { Connection, DestinationDataStore, Operation, SourceDataStore } from "./sync-manifest";
+import type { TransformedOperationWithSource } from "../event-store/event-store.ts";
+import type { WorkspaceDefinition } from "../workspace/workspace.ts";
+import type { ConsumerSchemaSchema, PublicSchemaSchema, SyncManifestSchema } from "./manifest.ts";
+import type {
+  Connection,
+  DestinationDataStore,
+  Operation,
+  SourceDataStore,
+} from "./sync-manifest.ts";
 
 type Manifest = z.infer<typeof SyncManifestSchema>;
 

--- a/packages/contract/manifest/manifest-merger.test.ts
+++ b/packages/contract/manifest/manifest-merger.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, test } from "bun:test";
 
 import { z } from "zod";
 
-import { ConsumerSchemaSchema, PublicSchemaSchema, SyncManifestSchema } from "./manifest";
-import { ManifestMerger } from "./manifest-merger";
-import type { Connection } from "./sync-manifest";
+import { ConsumerSchemaSchema, PublicSchemaSchema, SyncManifestSchema } from "./manifest.ts";
+import { ManifestMerger } from "./manifest-merger.ts";
+import type { Connection } from "./sync-manifest.ts";
 
 type Manifest = z.infer<typeof SyncManifestSchema>;
 

--- a/packages/contract/manifest/manifest-merger.ts
+++ b/packages/contract/manifest/manifest-merger.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { ConsumerSchemaSchema, PublicSchemaSchema, SyncManifestSchema } from "./manifest";
+import { ConsumerSchemaSchema, PublicSchemaSchema, SyncManifestSchema } from "./manifest.ts";
 
 /** Represents the location context for a merge operation */
 export interface MergeLocation {

--- a/packages/contract/manifest/manifest.ts
+++ b/packages/contract/manifest/manifest.ts
@@ -160,4 +160,4 @@ export {
   type ManifestDiagnostic,
   type VerificationResult,
   verifyManifests,
-} from "./verify-manifest";
+} from "./verify-manifest.ts";

--- a/packages/contract/manifest/sync-manifest.test.ts
+++ b/packages/contract/manifest/sync-manifest.test.ts
@@ -2,8 +2,8 @@ import { expect, test } from "bun:test";
 
 import { z } from "zod";
 
-import { SyncManifestSchema } from "./manifest";
-import { SyncManifest } from "./sync-manifest";
+import { SyncManifestSchema } from "./manifest.ts";
+import { SyncManifest } from "./sync-manifest.ts";
 
 type Manifest = z.infer<typeof SyncManifestSchema>;
 

--- a/packages/contract/manifest/sync-manifest.ts
+++ b/packages/contract/manifest/sync-manifest.ts
@@ -1,15 +1,14 @@
 import { z } from "zod";
 
-import type { TransformedOperationWithSource } from "@rejot-dev/contract/event-store";
-import { getLogger } from "@rejot-dev/contract/logger";
-
+import type { TransformedOperationWithSource } from "../event-store/event-store.ts";
+import { getLogger } from "../logger/logger.ts";
 import {
   type ConnectionConfigSchema,
   ConsumerSchemaSchema,
   type DataStoreConfigSchema,
   type PublicSchemaSchema,
   SyncManifestSchema,
-} from "./manifest";
+} from "./manifest.ts";
 import {
   getConnectionBySlugHelper,
   getConnectionsHelper,
@@ -21,13 +20,13 @@ import {
   getPublicSchemasForOperationHelper,
   getPublicSchemasHelper,
   getSourceDataStoresHelper,
-} from "./manifest-helpers";
+} from "./manifest-helpers.ts";
 import {
   type ExternalPublicSchemaReference,
   type ManifestDiagnostic,
   type VerificationResult,
   verifyManifests,
-} from "./verify-manifest";
+} from "./verify-manifest.ts";
 
 const log = getLogger(import.meta.url);
 

--- a/packages/contract/manifest/verify-manifest.test.ts
+++ b/packages/contract/manifest/verify-manifest.test.ts
@@ -2,8 +2,8 @@ import { expect, test } from "bun:test";
 
 import { z } from "zod";
 
-import { PublicSchemaSchema, SyncManifestSchema } from "./manifest";
-import { verifyManifests, verifyManifestsWithPaths } from "./verify-manifest";
+import { PublicSchemaSchema, SyncManifestSchema } from "./manifest.ts";
+import { verifyManifests, verifyManifestsWithPaths } from "./verify-manifest.ts";
 
 type Manifest = z.infer<typeof SyncManifestSchema>;
 

--- a/packages/contract/manifest/verify-manifest.ts
+++ b/packages/contract/manifest/verify-manifest.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
-import type { ManifestWithPath } from "../workspace/workspace";
-import { SyncManifestSchema } from "./manifest";
+import type { ManifestWithPath } from "../workspace/workspace.ts";
+import { SyncManifestSchema } from "./manifest.ts";
 
 export type ManifestDiagnosticSeverity = "error" | "warning";
 

--- a/packages/contract/message-bus/message-bus.test.ts
+++ b/packages/contract/message-bus/message-bus.test.ts
@@ -1,6 +1,7 @@
-import { test, expect } from "bun:test";
-import { InMemoryMessageBus } from "./message-bus";
-import type { OperationMessage } from "./message-bus";
+import { expect, test } from "bun:test";
+
+import type { OperationMessage } from "./message-bus.ts";
+import { InMemoryMessageBus } from "./message-bus.ts";
 
 const createTestMessage = (id: number): OperationMessage => ({
   transactionId: `test-${id}`,

--- a/packages/contract/message-bus/message-bus.ts
+++ b/packages/contract/message-bus/message-bus.ts
@@ -1,5 +1,5 @@
-import type { TransformedOperationWithSource } from "../event-store/event-store";
-import type { Cursor } from "../cursor/cursors";
+import type { Cursor } from "../cursor/cursors.ts";
+import type { TransformedOperationWithSource } from "../event-store/event-store.ts";
 
 export interface OperationMessage {
   transactionId: string;

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -17,90 +17,112 @@
   },
   "exports": {
     "./adapter": {
+      "bun": "./adapter/adapter.ts",
       "types": "./dist/adapter/adapter.d.ts",
       "default": "./dist/adapter/adapter.js"
     },
     "./collect": {
+      "bun": "./collect/collect.ts",
       "types": "./dist/collect/collect.d.ts",
       "default": "./dist/collect/collect.js"
     },
     "./collect/mock": {
+      "bun": "./collect/mock-schema-collector.ts",
       "types": "./dist/collect/mock-schema-collector.d.ts",
       "default": "./dist/collect/mock-schema-collector.js"
     },
     "./consumer-schema": {
+      "bun": "./consumer-schema/consumer-schema.ts",
       "types": "./dist/consumer-schema/consumer-schema.d.ts",
       "default": "./dist/consumer-schema/consumer-schema.js"
     },
     "./cursor": {
+      "bun": "./cursor/cursors.ts",
       "types": "./dist/cursor/cursors.d.ts",
       "default": "./dist/cursor/cursors.js"
     },
     "./event-store": {
+      "bun": "./event-store/event-store.ts",
       "types": "./dist/event-store/event-store.d.ts",
       "default": "./dist/event-store/event-store.js"
     },
     "./event-store-message-bus": {
+      "bun": "./event-store/event-store-message-bus.ts",
       "types": "./dist/event-store/event-store-message-bus.d.ts",
       "default": "./dist/event-store/event-store-message-bus.js"
     },
     "./event-store/in-memory-event-store": {
+      "bun": "./event-store/in-memory-event-store.ts",
       "types": "./dist/event-store/in-memory-event-store.d.ts",
       "default": "./dist/event-store/in-memory-event-store.js"
     },
     "./logger": {
+      "bun": "./logger/logger.ts",
       "types": "./dist/logger/logger.d.ts",
       "default": "./dist/logger/logger.js"
     },
     "./manifest": {
+      "bun": "./manifest/manifest.ts",
       "types": "./dist/manifest/manifest.d.ts",
       "default": "./dist/manifest/manifest.js"
     },
     "./manifest.fs": {
+      "bun": "./manifest/manifest.fs.ts",
       "types": "./dist/manifest/manifest.fs.d.ts",
       "default": "./dist/manifest/manifest.fs.js"
     },
     "./manifest-helpers": {
+      "bun": "./manifest/manifest-helpers.ts",
       "types": "./dist/manifest/manifest-helpers.d.ts",
       "default": "./dist/manifest/manifest-helpers.js"
     },
     "./manifest-merger": {
+      "bun": "./manifest/manifest-merger.ts",
       "types": "./dist/manifest/manifest-merger.d.ts",
       "default": "./dist/manifest/manifest-merger.js"
     },
     "./sync-manifest": {
+      "bun": "./manifest/sync-manifest.ts",
       "types": "./dist/manifest/sync-manifest.d.ts",
       "default": "./dist/manifest/sync-manifest.js"
     },
     "./postgres": {
+      "bun": "./postgres/postgres.ts",
       "types": "./dist/postgres/postgres.d.ts",
       "default": "./dist/postgres/postgres.js"
     },
     "./public-schema": {
+      "bun": "./public-schema/public-schema.ts",
       "types": "./dist/public-schema/public-schema.d.ts",
       "default": "./dist/public-schema/public-schema.js"
     },
     "./workspace": {
+      "bun": "./workspace/workspace.ts",
       "types": "./dist/workspace/workspace.d.ts",
       "default": "./dist/workspace/workspace.js"
     },
     "./error": {
+      "bun": "./error/error.ts",
       "types": "./dist/error/error.d.ts",
       "default": "./dist/error/error.js"
     },
     "./sync": {
+      "bun": "./sync/sync.ts",
       "types": "./dist/sync/sync.d.ts",
       "default": "./dist/sync/sync.js"
     },
     "./schema-validator": {
+      "bun": "./schema-validator.ts",
       "types": "./dist/schema-validator.d.ts",
       "default": "./dist/schema-validator.js"
     },
     "./message-bus": {
+      "bun": "./message-bus/message-bus.ts",
       "types": "./dist/message-bus/message-bus.d.ts",
       "default": "./dist/message-bus/message-bus.js"
     },
     "./json-schema": {
+      "bun": "./json-schema/json-schema.ts",
       "types": "./dist/json-schema/json-schema.d.ts",
       "default": "./dist/json-schema/json-schema.js"
     }

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -11,31 +11,99 @@
   "scripts": {
     "check": "tsc --noEmit",
     "prepack": "bun run manifest-jsonschema.ts > schema.json",
+    "build": "tsc",
+    "clean": "rm -rf dist",
     "manifest:schema": "bun run manifest-jsonschema.ts"
   },
   "exports": {
-    "./adapter": "./adapter/adapter.ts",
-    "./collect": "./collect/collect.ts",
-    "./collect/mock": "./collect/mock-schema-collector.ts",
-    "./consumer-schema": "./consumer-schema/consumer-schema.ts",
-    "./cursor": "./cursor/cursors.ts",
-    "./event-store": "./event-store/event-store.ts",
-    "./event-store-message-bus": "./event-store/event-store-message-bus.ts",
-    "./event-store/in-memory-event-store": "./event-store/in-memory-event-store.ts",
-    "./logger": "./logger/logger.ts",
-    "./manifest": "./manifest/manifest.ts",
-    "./manifest.fs": "./manifest/manifest.fs.ts",
-    "./manifest-helpers": "./manifest/manifest-helpers.ts",
-    "./manifest-merger": "./manifest/manifest-merger.ts",
-    "./sync-manifest": "./manifest/sync-manifest.ts",
-    "./postgres": "./postgres/postgres.ts",
-    "./public-schema": "./public-schema/public-schema.ts",
-    "./workspace": "./workspace/workspace.ts",
-    "./error": "./error/error.ts",
-    "./sync": "./sync/sync.ts",
-    "./schema-validator": "./schema-validator.ts",
-    "./message-bus": "./message-bus/message-bus.ts",
-    "./json-schema": "./json-schema/json-schema.ts"
+    "./adapter": {
+      "types": "./dist/adapter/adapter.d.ts",
+      "default": "./dist/adapter/adapter.js"
+    },
+    "./collect": {
+      "types": "./dist/collect/collect.d.ts",
+      "default": "./dist/collect/collect.js"
+    },
+    "./collect/mock": {
+      "types": "./dist/collect/mock-schema-collector.d.ts",
+      "default": "./dist/collect/mock-schema-collector.js"
+    },
+    "./consumer-schema": {
+      "types": "./dist/consumer-schema/consumer-schema.d.ts",
+      "default": "./dist/consumer-schema/consumer-schema.js"
+    },
+    "./cursor": {
+      "types": "./dist/cursor/cursors.d.ts",
+      "default": "./dist/cursor/cursors.js"
+    },
+    "./event-store": {
+      "types": "./dist/event-store/event-store.d.ts",
+      "default": "./dist/event-store/event-store.js"
+    },
+    "./event-store-message-bus": {
+      "types": "./dist/event-store/event-store-message-bus.d.ts",
+      "default": "./dist/event-store/event-store-message-bus.js"
+    },
+    "./event-store/in-memory-event-store": {
+      "types": "./dist/event-store/in-memory-event-store.d.ts",
+      "default": "./dist/event-store/in-memory-event-store.js"
+    },
+    "./logger": {
+      "types": "./dist/logger/logger.d.ts",
+      "default": "./dist/logger/logger.js"
+    },
+    "./manifest": {
+      "types": "./dist/manifest/manifest.d.ts",
+      "default": "./dist/manifest/manifest.js"
+    },
+    "./manifest.fs": {
+      "types": "./dist/manifest/manifest.fs.d.ts",
+      "default": "./dist/manifest/manifest.fs.js"
+    },
+    "./manifest-helpers": {
+      "types": "./dist/manifest/manifest-helpers.d.ts",
+      "default": "./dist/manifest/manifest-helpers.js"
+    },
+    "./manifest-merger": {
+      "types": "./dist/manifest/manifest-merger.d.ts",
+      "default": "./dist/manifest/manifest-merger.js"
+    },
+    "./sync-manifest": {
+      "types": "./dist/manifest/sync-manifest.d.ts",
+      "default": "./dist/manifest/sync-manifest.js"
+    },
+    "./postgres": {
+      "types": "./dist/postgres/postgres.d.ts",
+      "default": "./dist/postgres/postgres.js"
+    },
+    "./public-schema": {
+      "types": "./dist/public-schema/public-schema.d.ts",
+      "default": "./dist/public-schema/public-schema.js"
+    },
+    "./workspace": {
+      "types": "./dist/workspace/workspace.d.ts",
+      "default": "./dist/workspace/workspace.js"
+    },
+    "./error": {
+      "types": "./dist/error/error.d.ts",
+      "default": "./dist/error/error.js"
+    },
+    "./sync": {
+      "types": "./dist/sync/sync.d.ts",
+      "default": "./dist/sync/sync.js"
+    },
+    "./schema-validator": {
+      "types": "./dist/schema-validator.d.ts",
+      "default": "./dist/schema-validator.js"
+    },
+    "./message-bus": {
+      "types": "./dist/message-bus/message-bus.d.ts",
+      "default": "./dist/message-bus/message-bus.js"
+    },
+    "./json-schema": {
+      "types": "./dist/json-schema/json-schema.d.ts",
+      "default": "./dist/json-schema/json-schema.js"
+    }
   },
   "type": "module",
   "dependencies": {

--- a/packages/contract/public-schema/public-schema-transformation.repository.ts
+++ b/packages/contract/public-schema/public-schema-transformation.repository.ts
@@ -1,6 +1,7 @@
-import type { TableOperation } from "@rejot-dev/contract/sync";
 import { z } from "zod";
+
 import { PublicSchemaSchema } from "../manifest/manifest.ts";
+import type { TableOperation } from "../sync/sync.ts";
 
 export interface IPublicSchemaTransformationRepository {
   getPublicSchemasForOperation(

--- a/packages/contract/public-schema/public-schema.ts
+++ b/packages/contract/public-schema/public-schema.ts
@@ -1,7 +1,8 @@
-import { zodToJsonSchema } from "zod-to-json-schema";
 import { z } from "zod";
-import { PublicSchemaSchema } from "../manifest/manifest.ts";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
 import { JsonSchemaSchema } from "../json-schema/json-schema.ts";
+import { PublicSchemaSchema } from "../manifest/manifest.ts";
 
 export type PublicSchemaTransformation = {
   transformationType: "postgresql";
@@ -110,4 +111,4 @@ export function deserializePublicSchema(schema: string): PublicSchemaData {
   return data;
 }
 
-export { type IPublicSchemaTransformationRepository } from "./public-schema-transformation.repository";
+export { type IPublicSchemaTransformationRepository } from "./public-schema-transformation.repository.ts";

--- a/packages/contract/schema-validator.test.ts
+++ b/packages/contract/schema-validator.test.ts
@@ -1,7 +1,9 @@
-import { describe, test, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
+
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
-import { SchemaValidator, type ISchemaLike } from "./schema-validator";
+
+import { type ISchemaLike, SchemaValidator } from "./schema-validator.ts";
 
 describe("SchemaValidator", () => {
   const testSchema: ISchemaLike = {

--- a/packages/contract/schema-validator.ts
+++ b/packages/contract/schema-validator.ts
@@ -1,6 +1,7 @@
 import Ajv from "ajv";
 import addFormats from "ajv-formats";
-import type { JsonSchema } from "./json-schema/json-schema";
+
+import type { JsonSchema } from "./json-schema/json-schema.ts";
 
 type ValidationResult =
   | {

--- a/packages/contract/sync/sync.ts
+++ b/packages/contract/sync/sync.ts
@@ -1,5 +1,6 @@
 import type { z } from "zod";
-import type { ConnectionConfigSchema } from "../manifest/manifest";
+
+import type { ConnectionConfigSchema } from "../manifest/manifest.ts";
 
 type OperationType = "insert" | "update" | "delete";
 

--- a/packages/contract/workspace/workspace.ts
+++ b/packages/contract/workspace/workspace.ts
@@ -1,7 +1,7 @@
 import type { z } from "zod";
 
-import type { SyncManifestSchema } from "../manifest/manifest";
-import { type VerificationResult, verifyManifestsWithPaths } from "../manifest/verify-manifest";
+import type { SyncManifestSchema } from "../manifest/manifest.ts";
+import { type VerificationResult, verifyManifestsWithPaths } from "../manifest/verify-manifest.ts";
 
 export interface ManifestWithPath {
   /** Path is relative to the rootPath in the workspace. */

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,7 +16,8 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "emitDeclarationOnly": true,
+    "rewriteRelativeImportExtensions": true,
+    "emitDeclarationOnly": false,
     "isolatedDeclarations": false,
     "isolatedModules": true,
     // Best practices


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
The contract package now builds and publishes as JavaScript with bundled type declarations, making it easier to consume in other projects.

- **Dependencies**
  - Updated package exports to point to built JavaScript and type declaration files in the dist directory.
  - Adjusted tsconfig settings and import paths for compatibility with JavaScript output and type generation.

<!-- End of auto-generated description by mrge. -->

