### PR TITLE
Lint for adding .ts extension on relative imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -38,6 +38,7 @@ export default tseslint.config(
       // ...unicornFixableRules,
       "local/require-local-package-deps": "error",
       "local/disallow-package-name-imports": "warn",
+      "local/require-relative-import-extension": "error",
       "@typescript-eslint/no-unused-vars": [
         "error",
         {
@@ -79,6 +80,13 @@ export default tseslint.config(
         },
       ],
       "simple-import-sort/exports": "warn",
+    },
+  },
+  {
+    // Disable the rule for apps/ and specific packages
+    files: ["scripts/**/*", "apps/**/*", "packages/api-interface-controller/**/*"],
+    rules: {
+      "local/require-relative-import-extension": "off",
     },
   },
   {

--- a/packages/adapter-postgres/src/adapter/pg-consumer-schema-transformation-adapter.test.ts
+++ b/packages/adapter-postgres/src/adapter/pg-consumer-schema-transformation-adapter.test.ts
@@ -5,8 +5,8 @@ import { z } from "zod";
 import type { OperationTransformationPair } from "@rejot-dev/contract/adapter";
 import type { PostgresConsumerSchemaTransformationSchema } from "@rejot-dev/contract/manifest";
 
-import { PostgresConsumerDataStoreSchemaManager } from "../data-store/pg-consumer-data-store-schema-manager";
-import { getTestConnectionConfig, pgRollbackDescribe } from "../util/postgres-test-utils";
+import { PostgresConsumerDataStoreSchemaManager } from "../data-store/pg-consumer-data-store-schema-manager.ts";
+import { getTestConnectionConfig, pgRollbackDescribe } from "../util/postgres-test-utils.ts";
 import { PostgresConnectionAdapter } from "./pg-connection-adapter.ts";
 import { PostgresConsumerSchemaTransformationAdapter } from "./pg-consumer-schema-transformation-adapter.ts";
 

--- a/packages/adapter-postgres/src/adapter/pg-consumer-schema-validation-adapter.test.ts
+++ b/packages/adapter-postgres/src/adapter/pg-consumer-schema-validation-adapter.test.ts
@@ -4,8 +4,8 @@ import { z } from "zod";
 
 import { createConsumerSchema } from "@rejot-dev/contract/consumer-schema";
 import { createPublicSchema } from "@rejot-dev/contract/public-schema";
+import { initSqlparser } from "@rejot-dev/sqlparser";
 
-import { initSqlparser } from "../../../sqlparser";
 import { PostgresConsumerSchemaValidationAdapter } from "./pg-consumer-schema-validation-adapter.ts";
 
 // Initialize the SQL parser before running tests

--- a/packages/adapter-postgres/src/adapter/pg-consumer-schema-validation-adapter.ts
+++ b/packages/adapter-postgres/src/adapter/pg-consumer-schema-validation-adapter.ts
@@ -8,7 +8,7 @@ import type { PublicSchemaSchema } from "@rejot-dev/contract/manifest";
 import type { ConsumerSchemaSchema } from "@rejot-dev/contract/manifest";
 import type { PostgresConsumerSchemaTransformationSchema } from "@rejot-dev/contract/manifest";
 
-import { validateConsumerSchema } from "../sql-transformer/sql-transformer";
+import { validateConsumerSchema } from "../sql-transformer/sql-transformer.ts";
 
 export class PostgresConsumerSchemaValidationAdapter
   implements

--- a/packages/adapter-postgres/src/adapter/pg-introspection-adapter.test.ts
+++ b/packages/adapter-postgres/src/adapter/pg-introspection-adapter.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, expect, test } from "bun:test";
 
-import { getTestConnectionConfig, pgRollbackDescribe } from "../util/postgres-test-utils";
+import { getTestConnectionConfig, pgRollbackDescribe } from "../util/postgres-test-utils.ts";
 import { PostgresConnectionAdapter } from "./pg-connection-adapter.ts";
 import { PostgresIntrospectionAdapter } from "./pg-introspection-adapter.ts";
 

--- a/packages/adapter-postgres/src/adapter/pg-transformations.ts
+++ b/packages/adapter-postgres/src/adapter/pg-transformations.ts
@@ -1,5 +1,5 @@
-import type { PublicSchemaTransformation } from "@rejot-dev/contract/public-schema";
 import type { ConsumerSchemaTransformation } from "@rejot-dev/contract/consumer-schema";
+import type { PublicSchemaTransformation } from "@rejot-dev/contract/public-schema";
 
 export function createPostgresPublicSchemaTransformation(
   table: string,

--- a/packages/adapter-postgres/src/data-store/pg-consumer-data-store-schema-manager.ts
+++ b/packages/adapter-postgres/src/data-store/pg-consumer-data-store-schema-manager.ts
@@ -1,5 +1,5 @@
-import type { PostgresClient } from "../util/postgres-client";
-import { PgMigrationManager, type Migration } from "../migration/pg-migration-manager";
+import { type Migration, PgMigrationManager } from "../migration/pg-migration-manager.ts";
+import type { PostgresClient } from "../util/postgres-client.ts";
 
 export const SCHEMA_NAME = "rejot_data_store";
 export const PUBLIC_SCHEMA_STATE_TABLE = "public_schema_state";

--- a/packages/adapter-postgres/src/data-store/pg-data-store-repository.test.ts
+++ b/packages/adapter-postgres/src/data-store/pg-data-store-repository.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, expect, test } from "bun:test";
 
-import { PostgresClient } from "../util/postgres-client";
-import { pgRollbackDescribe } from "../util/postgres-test-utils";
+import { PostgresClient } from "../util/postgres-client.ts";
+import { pgRollbackDescribe } from "../util/postgres-test-utils.ts";
 import { PostgresConsumerDataStoreSchemaManager } from "./pg-consumer-data-store-schema-manager.ts";
 import { getPublicSchemaStates, updatePublicSchemaState } from "./pg-data-store-repository.ts";
 

--- a/packages/adapter-postgres/src/data-store/pg-data-store-repository.ts
+++ b/packages/adapter-postgres/src/data-store/pg-data-store-repository.ts
@@ -1,4 +1,4 @@
-import type { PostgresClient } from "../util/postgres-client";
+import type { PostgresClient } from "../util/postgres-client.ts";
 
 export type PublicSchemaReference = {
   manifestSlug: string;

--- a/packages/adapter-postgres/src/data-store/pg-replication-repository.ts
+++ b/packages/adapter-postgres/src/data-store/pg-replication-repository.ts
@@ -1,7 +1,7 @@
 import { getLogger } from "@rejot-dev/contract/logger";
 
-import type { PostgresClient } from "../util/postgres-client";
-import { isPostgresError, PG_DUPLICATE_OBJECT } from "../util/postgres-error-codes";
+import type { PostgresClient } from "../util/postgres-client.ts";
+import { isPostgresError, PG_DUPLICATE_OBJECT } from "../util/postgres-error-codes.ts";
 
 const log = getLogger(import.meta.url);
 

--- a/packages/adapter-postgres/src/event-store/pg-event-store-repository.test.ts
+++ b/packages/adapter-postgres/src/event-store/pg-event-store-repository.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, expect, test } from "bun:test";
 
-import { PostgresClient } from "../util/postgres-client";
-import { pgRollbackDescribe } from "../util/postgres-test-utils";
+import { PostgresClient } from "../util/postgres-client.ts";
+import { pgRollbackDescribe } from "../util/postgres-test-utils.ts";
 import { PostgresEventStoreRepository } from "./pg-event-store-repository.ts";
 import { EventStoreSchemaManager } from "./pg-event-store-schema-manager.ts";
 

--- a/packages/adapter-postgres/src/event-store/pg-event-store-repository.ts
+++ b/packages/adapter-postgres/src/event-store/pg-event-store-repository.ts
@@ -1,6 +1,7 @@
-import type { PostgresClient } from "../util/postgres-client";
-import type { TransformedOperationWithSource } from "@rejot-dev/contract/event-store";
 import type { PublicSchemaReference } from "@rejot-dev/contract/cursor";
+import type { TransformedOperationWithSource } from "@rejot-dev/contract/event-store";
+
+import type { PostgresClient } from "../util/postgres-client.ts";
 
 type EventRow = {
   operation: "insert" | "update" | "delete";

--- a/packages/adapter-postgres/src/event-store/pg-event-store-schema-manager.ts
+++ b/packages/adapter-postgres/src/event-store/pg-event-store-schema-manager.ts
@@ -1,5 +1,5 @@
-import type { PostgresClient } from "../util/postgres-client";
-import { PgMigrationManager, type Migration } from "../migration/pg-migration-manager";
+import { type Migration, PgMigrationManager } from "../migration/pg-migration-manager.ts";
+import type { PostgresClient } from "../util/postgres-client.ts";
 
 export const EVENT_STORE_MIGRATIONS: Migration[] = [
   {

--- a/packages/adapter-postgres/src/event-store/postgres-event-store.test.ts
+++ b/packages/adapter-postgres/src/event-store/postgres-event-store.test.ts
@@ -8,7 +8,7 @@ import type {
   TransformedOperationWithSourceUpdate,
 } from "@rejot-dev/contract/event-store";
 
-import { pgRollbackDescribe } from "../util/postgres-test-utils";
+import { pgRollbackDescribe } from "../util/postgres-test-utils.ts";
 import { PostgresEventStore } from "./postgres-event-store.ts";
 
 const TEST_SCHEMA_NAME = "rejot_events";

--- a/packages/adapter-postgres/src/event-store/postgres-event-store.ts
+++ b/packages/adapter-postgres/src/event-store/postgres-event-store.ts
@@ -3,7 +3,7 @@ import type { IEventStore, TransformedOperationWithSource } from "@rejot-dev/con
 import { getLogger } from "@rejot-dev/contract/logger";
 import type { OperationMessage } from "@rejot-dev/contract/message-bus";
 
-import { PostgresClient } from "../util/postgres-client";
+import { PostgresClient } from "../util/postgres-client.ts";
 import { PostgresEventStoreRepository } from "./pg-event-store-repository.ts";
 import { EventStoreSchemaManager } from "./pg-event-store-schema-manager.ts";
 

--- a/packages/adapter-postgres/src/migration/pg-migration-manager.ts
+++ b/packages/adapter-postgres/src/migration/pg-migration-manager.ts
@@ -1,6 +1,6 @@
 import { getLogger } from "@rejot-dev/contract/logger";
 
-import type { PostgresClient } from "../util/postgres-client";
+import type { PostgresClient } from "../util/postgres-client.ts";
 
 const log = getLogger(import.meta.url);
 

--- a/packages/adapter-postgres/src/postgres-replication-listener.test.ts
+++ b/packages/adapter-postgres/src/postgres-replication-listener.test.ts
@@ -2,9 +2,9 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import type { TableOperationDelete } from "@rejot-dev/contract/sync";
 
-import type { Operation } from "./postgres-replication-listener";
+import type { Operation } from "./postgres-replication-listener.ts";
 import { PostgresReplicationListener } from "./postgres-replication-listener.ts";
-import type { PostgresClient } from "./util/postgres-client";
+import type { PostgresClient } from "./util/postgres-client.ts";
 import { getTestClient } from "./util/postgres-test-utils.ts";
 
 const TEST_TABLE_NAME = "test_pg_rep_list_table";

--- a/packages/adapter-postgres/src/postgres-source.test.ts
+++ b/packages/adapter-postgres/src/postgres-source.test.ts
@@ -1,8 +1,10 @@
-import { test, expect, beforeEach, afterEach, describe } from "bun:test";
-import { PostgresSource } from "./postgres-source.ts";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
 import { watermarkFromTransaction } from "@rejot-dev/sync/sync-controller";
-import { getTestClient } from "./util/postgres-test-utils.ts";
+
+import { PostgresSource } from "./postgres-source.ts";
 import type { PostgresClient } from "./util/postgres-client.ts";
+import { getTestClient } from "./util/postgres-test-utils.ts";
 
 const TEST_TABLE_NAME = "test_pg_source";
 const TEST_PUBLICATION_NAME = "test_publication";

--- a/packages/adapter-postgres/src/sql-transformer/sql-transformation-cache.ts
+++ b/packages/adapter-postgres/src/sql-transformer/sql-transformation-cache.ts
@@ -1,9 +1,9 @@
 import {
-  type PlaceholderInfo,
-  type Statement,
-  parseSql,
   findPlaceholders,
   initSqlparser,
+  parseSql,
+  type PlaceholderInfo,
+  type Statement,
 } from "@rejot-dev/sqlparser";
 
 interface ParsedSqlResult {

--- a/packages/adapter-postgres/src/sql-transformer/sql-transformer.test.ts
+++ b/packages/adapter-postgres/src/sql-transformer/sql-transformer.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 
-import { initSqlparser } from "../../../sqlparser";
+import { initSqlparser } from "@rejot-dev/sqlparser";
+
 import {
   convertNamedToPositionalPlaceholders,
   validateSqlPlaceholders,

--- a/packages/adapter-postgres/src/util/postgres-client.test.ts
+++ b/packages/adapter-postgres/src/util/postgres-client.test.ts
@@ -1,7 +1,9 @@
-import { test, expect, describe, beforeAll, afterAll } from "bun:test";
-import { getTestClient, pgRollbackDescribe } from "./postgres-test-utils.ts";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
 import { DatabaseError } from "pg";
+
 import { PG_INVALID_TEXT_REPRESENTATION } from "./postgres-error-codes.ts";
+import { getTestClient, pgRollbackDescribe } from "./postgres-test-utils.ts";
 
 describe("PostgresClient", () => {
   const randomTableName = `test_${Math.random().toString(36).substring(2, 15)}`;

--- a/packages/contract-tools/collect/file-finder.mock.ts
+++ b/packages/contract-tools/collect/file-finder.mock.ts
@@ -1,4 +1,4 @@
-import type { IFileFinder, SearchOptions, SearchResult } from "./file-finder";
+import type { IFileFinder, SearchOptions, SearchResult } from "./file-finder.ts";
 
 export class MockFileFinder implements IFileFinder {
   private mockResults: SearchResult[] = [];

--- a/packages/contract-tools/collect/file-finder.test.ts
+++ b/packages/contract-tools/collect/file-finder.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { isAbsolute, join } from "node:path";
 
 import { FileFinder } from "./file-finder.ts";
-import type { GitIgnorePattern } from "./git-ignore";
+import type { GitIgnorePattern } from "./git-ignore.ts";
 
 describe("file-finder", () => {
   let tmpDir: string;

--- a/packages/contract-tools/collect/file-finder.ts
+++ b/packages/contract-tools/collect/file-finder.ts
@@ -2,7 +2,7 @@ import { spawn } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
 
-import type { GitIgnorePattern } from "./git-ignore";
+import type { GitIgnorePattern } from "./git-ignore.ts";
 
 export interface SearchResult {
   file: string;

--- a/packages/contract-tools/collect/git-ignore.ts
+++ b/packages/contract-tools/collect/git-ignore.ts
@@ -1,5 +1,5 @@
-import { readFile, access } from "node:fs/promises";
 import { constants } from "node:fs";
+import { access, readFile } from "node:fs/promises";
 import path from "node:path";
 
 export interface GitIgnorePattern {

--- a/packages/contract-tools/collect/vibe-collect.ts
+++ b/packages/contract-tools/collect/vibe-collect.ts
@@ -8,8 +8,8 @@ import { getLogger } from "@rejot-dev/contract/logger";
 import type { ConsumerSchemaSchema, PublicSchemaSchema } from "@rejot-dev/contract/manifest";
 import { ManifestMerger, type MergeDiagnostic } from "@rejot-dev/contract/manifest-merger";
 
-import type { IManifestFileManager } from "../manifest/manifest-file-manager";
-import { ManifestPrinter } from "../manifest/manifest-printer";
+import type { IManifestFileManager } from "../manifest/manifest-file-manager.ts";
+import { ManifestPrinter } from "../manifest/manifest-printer.ts";
 import { type IFileFinder } from "./file-finder.ts";
 import { collectGitIgnore } from "./git-ignore.ts";
 

--- a/packages/contract-tools/manifest/manifest-file-manager.mock.ts
+++ b/packages/contract-tools/manifest/manifest-file-manager.mock.ts
@@ -4,7 +4,7 @@ import { SyncManifestSchema } from "@rejot-dev/contract/manifest";
 import type { MergedManifest } from "@rejot-dev/contract/manifest-merger";
 
 import type { InitManifestOptions } from "./manifest.fs";
-import type { IManifestFileManager } from "./manifest-file-manager";
+import type { IManifestFileManager } from "./manifest-file-manager.ts";
 
 type Manifest = z.infer<typeof SyncManifestSchema>;
 

--- a/packages/contract-tools/manifest/manifest-workspace-resolver.ts
+++ b/packages/contract-tools/manifest/manifest-workspace-resolver.ts
@@ -1,11 +1,12 @@
 import { dirname, join } from "node:path";
 
+import { z } from "zod";
+
 import { ReJotError } from "@rejot-dev/contract/error";
 import { getLogger } from "@rejot-dev/contract/logger";
 import { SyncManifestSchema } from "@rejot-dev/contract/manifest";
 import { SyncManifest, type SyncManifestOptions } from "@rejot-dev/contract/sync-manifest";
 import type { ManifestWithPath, WorkspaceDefinition } from "@rejot-dev/contract/workspace";
-import { z } from "zod";
 
 import { DEFAULT_MANIFEST_FILENAME, readManifest, readManifestOrGetEmpty } from "./manifest.fs";
 import { findManifestPath } from "./manifest.fs";

--- a/packages/sqlparser/index.ts
+++ b/packages/sqlparser/index.ts
@@ -1,10 +1,11 @@
 import init, {
+  find_placeholders_wasm,
   parse_sql,
   statements_to_sql,
-  find_placeholders_wasm,
   // Note this package lives in a different repo.
 } from "@rejot-dev/sqlparser-wasm";
-import type { Query } from "./types";
+
+import type { Query } from "./types.ts";
 
 let initialized = false;
 export async function initSqlparser(): Promise<void> {

--- a/packages/sync/scripts/tail.ts
+++ b/packages/sync/scripts/tail.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env bun
 import { z } from "zod";
 
-import { fetchPublicSchemas, fetchRead } from "../src/sync-http-service/sync-http-service-fetch";
-import { CursorSchema } from "../src/sync-http-service/sync-http-service-routes";
+import { fetchPublicSchemas, fetchRead } from "../src/sync-http-service/sync-http-service-fetch.ts";
+import { CursorSchema } from "../src/sync-http-service/sync-http-service-routes.ts";
 
 async function main() {
   const port = process.argv[2] ? parseInt(process.argv[2], 10) : 3000;

--- a/packages/sync/src/_test/in-memory-source.ts
+++ b/packages/sync/src/_test/in-memory-source.ts
@@ -1,8 +1,8 @@
 import type {
   IDataSource,
-  TransformedOperation,
   TableOperation,
   Transaction,
+  TransformedOperation,
 } from "@rejot-dev/contract/sync";
 
 export class InMemorySource implements IDataSource {

--- a/packages/sync/src/_test/mock-sync-controller.ts
+++ b/packages/sync/src/_test/mock-sync-controller.ts
@@ -3,8 +3,8 @@ import { z } from "zod";
 import { type Cursor, Cursors } from "@rejot-dev/contract/cursor";
 import type { PublicSchemaSchema } from "@rejot-dev/contract/manifest";
 
-import type { ISyncController, SyncControllerState } from "../sync-controller/sync-controller";
-import type { ISyncHTTPController } from "../sync-http-service/sync-http-service";
+import type { ISyncController, SyncControllerState } from "../sync-controller/sync-controller.ts";
+import type { ISyncHTTPController } from "../sync-http-service/sync-http-service.ts";
 
 export class MockSyncController implements ISyncController {
   #cursors: Cursor[] = [];

--- a/packages/sync/src/manifest/manifest-transformation.repository.test.ts
+++ b/packages/sync/src/manifest/manifest-transformation.repository.test.ts
@@ -1,8 +1,11 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
+
 import { z } from "zod";
+
 import { SyncManifestSchema } from "@rejot-dev/contract/manifest";
-import { ManifestTransformationRepository } from "./manifest-transformation.repository.ts";
 import type { TableOperation } from "@rejot-dev/contract/sync";
+
+import { ManifestTransformationRepository } from "./manifest-transformation.repository.ts";
 
 type Manifest = z.infer<typeof SyncManifestSchema>;
 

--- a/packages/sync/src/manifest/manifest-transformation.repository.ts
+++ b/packages/sync/src/manifest/manifest-transformation.repository.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
-import { SyncManifestSchema, type PublicSchemaSchema } from "@rejot-dev/contract/manifest";
-import type { TableOperation } from "@rejot-dev/contract/sync";
+
+import { type PublicSchemaSchema, SyncManifestSchema } from "@rejot-dev/contract/manifest";
 import type { IPublicSchemaTransformationRepository } from "@rejot-dev/contract/public-schema";
+import type { TableOperation } from "@rejot-dev/contract/sync";
 type Manifest = z.infer<typeof SyncManifestSchema>;
 
 export class ManifestTransformationRepository implements IPublicSchemaTransformationRepository {

--- a/packages/sync/src/result-set-store.test.ts
+++ b/packages/sync/src/result-set-store.test.ts
@@ -1,4 +1,5 @@
-import { describe, test, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
+
 import { ResultSetStore } from "./result-set-store.ts";
 
 describe("Result set store", () => {

--- a/packages/sync/src/sync-controller.test.ts
+++ b/packages/sync/src/sync-controller.test.ts
@@ -1,12 +1,14 @@
+import { describe, expect, test } from "bun:test";
+
 import type {
   IDataSink,
   IDataSource,
-  Transaction,
   TableOperation,
+  Transaction,
   TransformedOperation,
 } from "@rejot-dev/contract/sync";
+
 import { SyncController } from "./sync-controller.ts";
-import { describe, test, expect } from "bun:test";
 
 function createWatermarkTransaction(type: "low" | "high", backfillId: string): Transaction {
   return {

--- a/packages/sync/src/sync-controller/external-sync-message-bus.test.ts
+++ b/packages/sync/src/sync-controller/external-sync-message-bus.test.ts
@@ -1,12 +1,12 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 
 import type { Cursor } from "@rejot-dev/contract/cursor";
+import { InMemoryEventStore } from "@rejot-dev/contract/event-store/in-memory-event-store";
 import { SyncManifest } from "@rejot-dev/contract/sync-manifest";
 
-import { InMemoryEventStore } from "../../../contract/event-store/in-memory-event-store";
-import { MockSyncController } from "../_test/mock-sync-controller";
-import type { ISyncServiceResolver } from "../sync-http-service/sync-http-resolver";
-import { SyncHTTPController } from "../sync-http-service/sync-http-service";
+import { MockSyncController } from "../_test/mock-sync-controller.ts";
+import type { ISyncServiceResolver } from "../sync-http-service/sync-http-resolver.ts";
+import { SyncHTTPController } from "../sync-http-service/sync-http-service.ts";
 import { ExternalSyncMessageBus } from "./external-sync-message-bus.ts";
 
 const TEST_PORT = 3334;

--- a/packages/sync/src/sync-controller/external-sync-message-bus.ts
+++ b/packages/sync/src/sync-controller/external-sync-message-bus.ts
@@ -4,8 +4,8 @@ import { getLogger } from "@rejot-dev/contract/logger";
 import type { ISubscribeMessageBus, OperationMessage } from "@rejot-dev/contract/message-bus";
 import type { SyncManifest } from "@rejot-dev/contract/sync-manifest";
 
-import type { ISyncServiceResolver } from "../sync-http-service/sync-http-resolver";
-import { fetchRead } from "../sync-http-service/sync-http-service-fetch";
+import type { ISyncServiceResolver } from "../sync-http-service/sync-http-resolver.ts";
+import { fetchRead } from "../sync-http-service/sync-http-service-fetch.ts";
 const State = {
   INITIAL: 1,
   PREPARED: 2,

--- a/packages/sync/src/sync-controller/public-schema-transformer.test.ts
+++ b/packages/sync/src/sync-controller/public-schema-transformer.test.ts
@@ -5,8 +5,8 @@ import { z } from "zod";
 import type { IPublicSchemaTransformationAdapter } from "@rejot-dev/contract/adapter";
 import type { PostgresPublicSchemaTransformationSchema } from "@rejot-dev/contract/manifest";
 import type { TableOperation, Transaction, TransformedOperation } from "@rejot-dev/contract/sync";
+import { SyncManifest } from "@rejot-dev/contract/sync-manifest";
 
-import { SyncManifest } from "../../../contract/manifest/sync-manifest";
 import { PublicSchemaTransformer } from "./public-schema-transformer.ts";
 
 describe("PublicSchemaTransformer", () => {

--- a/packages/sync/src/sync-controller/public-schema-transformer.ts
+++ b/packages/sync/src/sync-controller/public-schema-transformer.ts
@@ -5,8 +5,7 @@ import type { TransformedOperationWithSource } from "@rejot-dev/contract/event-s
 import { getLogger } from "@rejot-dev/contract/logger";
 import type { PublicSchemaTransformationSchema } from "@rejot-dev/contract/manifest";
 import type { Transaction } from "@rejot-dev/contract/sync";
-
-import type { SyncManifest } from "../../../contract/manifest/sync-manifest";
+import type { SyncManifest } from "@rejot-dev/contract/sync-manifest";
 
 const log = getLogger(import.meta.url);
 

--- a/packages/sync/src/sync-controller/sink-writer.test.ts
+++ b/packages/sync/src/sync-controller/sink-writer.test.ts
@@ -12,8 +12,8 @@ import type { IEventStore } from "@rejot-dev/contract/event-store";
 import type { PostgresConsumerSchemaTransformationSchema } from "@rejot-dev/contract/manifest";
 import type { IDataSink, TransformedOperation } from "@rejot-dev/contract/sync";
 import type { IDataSource } from "@rejot-dev/contract/sync";
+import { SyncManifest } from "@rejot-dev/contract/sync-manifest";
 
-import { SyncManifest } from "../../../contract/manifest/sync-manifest";
 import { SinkWriter } from "./sink-writer.ts";
 
 describe("SinkWriter", () => {

--- a/packages/sync/src/sync-controller/sink-writer.ts
+++ b/packages/sync/src/sync-controller/sink-writer.ts
@@ -10,8 +10,7 @@ import type { TransformedOperationWithSource } from "@rejot-dev/contract/event-s
 import { getLogger } from "@rejot-dev/contract/logger";
 import type { ConsumerSchemaTransformationSchema } from "@rejot-dev/contract/manifest";
 import type { IDataSink } from "@rejot-dev/contract/sync";
-
-import type { SyncManifest } from "../../../contract/manifest/sync-manifest";
+import type { SyncManifest } from "@rejot-dev/contract/sync-manifest";
 
 const log = getLogger(import.meta.url);
 

--- a/packages/sync/src/sync-controller/source-reader.test.ts
+++ b/packages/sync/src/sync-controller/source-reader.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
 import type { Transaction } from "@rejot-dev/contract/sync";
+import { SyncManifest } from "@rejot-dev/contract/sync-manifest";
 
-import { SyncManifest } from "../../../contract/manifest/sync-manifest";
-import { InMemoryConnectionAdapter } from "../_test/in-memory-adapter";
+import { InMemoryConnectionAdapter } from "../_test/in-memory-adapter.ts";
 import { SourceReader } from "./source-reader.ts";
 
 describe("SourceReader", () => {

--- a/packages/sync/src/sync-controller/source-reader.ts
+++ b/packages/sync/src/sync-controller/source-reader.ts
@@ -1,8 +1,7 @@
 import type { AnyIConnectionAdapter } from "@rejot-dev/contract/adapter";
 import { getLogger } from "@rejot-dev/contract/logger";
 import type { IDataSource, Transaction } from "@rejot-dev/contract/sync";
-
-import type { SyncManifest } from "../../../contract/manifest/sync-manifest";
+import type { SyncManifest } from "@rejot-dev/contract/sync-manifest";
 
 const log = getLogger(import.meta.url);
 

--- a/packages/sync/src/sync-controller/sync-controller.test.ts
+++ b/packages/sync/src/sync-controller/sync-controller.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, test } from "bun:test";
 
 import { InMemoryMessageBus } from "@rejot-dev/contract/message-bus";
 import type { Transaction } from "@rejot-dev/contract/sync";
+import { SyncManifest } from "@rejot-dev/contract/sync-manifest";
 
-import { SyncManifest } from "../../../contract/manifest/sync-manifest";
-import { InMemoryConnectionAdapter } from "../_test/in-memory-adapter";
+import { InMemoryConnectionAdapter } from "../_test/in-memory-adapter.ts";
 import { SyncController } from "./sync-controller.ts";
 
 describe("SyncController", () => {

--- a/packages/sync/src/sync-controller/sync-controller.ts
+++ b/packages/sync/src/sync-controller/sync-controller.ts
@@ -8,14 +8,14 @@ import {
 import { Cursors, cursorToString } from "@rejot-dev/contract/cursor";
 import { getLogger } from "@rejot-dev/contract/logger";
 import type { PublicSchemaSchema } from "@rejot-dev/contract/manifest";
+import { getNullCursorsForConsumingPublicSchemas } from "@rejot-dev/contract/manifest-helpers";
 import type { IPublishMessageBus, ISubscribeMessageBus } from "@rejot-dev/contract/message-bus";
+import type { SyncManifest } from "@rejot-dev/contract/sync-manifest";
 
-import type { SyncManifest } from "../../../contract/manifest/sync-manifest";
-import type { ISyncHTTPController } from "../sync-http-service/sync-http-service";
+import type { ISyncHTTPController } from "../sync-http-service/sync-http-service.ts";
 import { PublicSchemaTransformer } from "./public-schema-transformer.ts";
 import { SinkWriter } from "./sink-writer.ts";
 import { SourceReader } from "./source-reader.ts";
-import { getNullCursorsForConsumingPublicSchemas } from "@rejot-dev/contract/manifest-helpers";
 
 const log = getLogger(import.meta.url);
 

--- a/packages/sync/src/sync-http-service/sync-http-service-fetch.ts
+++ b/packages/sync/src/sync-http-service/sync-http-service-fetch.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import type { RequestParams, RouteConfig } from "../http-controller/http-controller";
+import type { RequestParams, RouteConfig } from "../http-controller/http-controller.ts";
 import { publicSchemasRoute, syncServiceReadRoute } from "./sync-http-service-routes.ts";
 
 function getFetchForRoute<T extends RouteConfig>(

--- a/packages/sync/src/sync-http-service/sync-http-service-routes.ts
+++ b/packages/sync/src/sync-http-service/sync-http-service-routes.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
-import type { RouteConfig } from "../http-controller/http-controller";
+
+import type { RouteConfig } from "../http-controller/http-controller.ts";
 
 export const PublicSchemaReferenceSchema = z.object({
   manifest: z.object({

--- a/packages/sync/src/sync-http-service/sync-http-service.test.ts
+++ b/packages/sync/src/sync-http-service/sync-http-service.test.ts
@@ -1,7 +1,8 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 
-import { InMemoryEventStore } from "../../../contract/event-store/in-memory-event-store";
-import { MockSyncController } from "../_test/mock-sync-controller";
+import { InMemoryEventStore } from "@rejot-dev/contract/event-store/in-memory-event-store";
+
+import { MockSyncController } from "../_test/mock-sync-controller.ts";
 import { SyncHTTPController } from "./sync-http-service.ts";
 import { fetchRead } from "./sync-http-service-fetch.ts";
 

--- a/packages/sync/src/sync-http-service/sync-http-service.ts
+++ b/packages/sync/src/sync-http-service/sync-http-service.ts
@@ -1,7 +1,7 @@
 import type { IEventStore } from "@rejot-dev/contract/event-store";
 
-import { HttpController } from "../http-controller/http-controller";
-import type { ISyncController } from "../sync-controller/sync-controller";
+import { HttpController } from "../http-controller/http-controller.ts";
+import type { ISyncController } from "../sync-controller/sync-controller.ts";
 import {
   dataStoreCursorsRoute,
   indexRoute,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Added a lint rule to require .ts extensions on all relative imports, and updated codebase to use .ts extensions for relative imports.

- **New Rules**
  - Enforced .ts extension on relative imports with a custom ESLint rule.
  - Disabled the rule for scripts, apps, and api-interface-controller packages.

- **Code Updates**
  - Updated all relative import paths to include .ts extensions across the codebase.

<!-- End of auto-generated description by mrge. -->

