### PR TITLE
Sync: use fastify for http-controller instead of Bun

### DIFF
--- a/apps/mcp/.npmrc
+++ b/apps/mcp/.npmrc
@@ -1,0 +1,2 @@
+
+@jsr:registry=https://npm.jsr.io

--- a/apps/rejot-cli/src/commands/manifest-datastore/manifest-datastore-list.command.ts
+++ b/apps/rejot-cli/src/commands/manifest-datastore/manifest-datastore-list.command.ts
@@ -16,6 +16,7 @@ export class ManifestDataStoreListCommand extends Command {
 
   public async run(): Promise<void> {
     const { flags } = await this.parse(ManifestDataStoreListCommand);
+
     const manifestPath = path.resolve(flags.manifest);
     const manifest = await readManifestOrGetEmpty(manifestPath);
 

--- a/apps/rejot-cli/src/commands/manifest-datastore/manifest-datastore.command.test.ts
+++ b/apps/rejot-cli/src/commands/manifest-datastore/manifest-datastore.command.test.ts
@@ -89,7 +89,6 @@ describe("ManifestDataStore commands", () => {
 
   describe("list datastores", () => {
     test("list empty datastores", async () => {
-      // Capture console output
       const logs: string[] = [];
       const originalLog = console.log;
       console.log = (message: string) => logs.push(message);

--- a/apps/rejot-cli/src/commands/sync-command.ts
+++ b/apps/rejot-cli/src/commands/sync-command.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 
 import { DEFAULT_PUBLICATION_NAME } from "@rejot-dev/adapter-postgres/consts";
 import { getLogger, setLogLevel } from "@rejot-dev/contract/logger";
-import { SyncController } from "@rejot-dev/sync/sync-controller";
+import { LegacySyncController } from "@rejot-dev/sync/legacy-sync-controller";
 
 import { Command, Flags } from "@oclif/core";
 
@@ -190,7 +190,7 @@ export default class SyncCommand extends Command {
     );
 
     // Create sync controller
-    const syncController = new SyncController({
+    const syncController = new LegacySyncController({
       source,
       sink,
     });

--- a/bun.lock
+++ b/bun.lock
@@ -252,6 +252,7 @@
       "version": "0.0.11",
       "dependencies": {
         "@rejot-dev/contract": "*",
+        "fastify": "^5.3.2",
       },
     },
   },
@@ -567,6 +568,18 @@
     "@eslint/object-schema": ["@eslint/object-schema@2.1.6", "", {}, "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA=="],
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.2.5", "", { "dependencies": { "@eslint/core": "^0.10.0", "levn": "^0.4.1" } }, "sha512-lB05FkqEdUg2AA0xEbUz0SnkXT1LcCTa438W4IWTUh4hdOnVbQyOJ81OrDXsJk/LSiJHubgGEFoR5EHq1NsH1A=="],
+
+    "@fastify/ajv-compiler": ["@fastify/ajv-compiler@4.0.2", "", { "dependencies": { "ajv": "^8.12.0", "ajv-formats": "^3.0.1", "fast-uri": "^3.0.0" } }, "sha512-Rkiu/8wIjpsf46Rr+Fitd3HRP+VsxUFDDeag0hs9L0ksfnwx2g7SPQQTFL0E8Qv+rfXzQOxBJnjUB9ITUDjfWQ=="],
+
+    "@fastify/error": ["@fastify/error@4.1.0", "", {}, "sha512-KeFcciOr1eo/YvIXHP65S94jfEEqn1RxTRBT1aJaHxY5FK0/GDXYozsQMMWlZoHgi8i0s+YtrLsgj/JkUUjSkQ=="],
+
+    "@fastify/fast-json-stringify-compiler": ["@fastify/fast-json-stringify-compiler@5.0.3", "", { "dependencies": { "fast-json-stringify": "^6.0.0" } }, "sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ=="],
+
+    "@fastify/forwarded": ["@fastify/forwarded@3.0.0", "", {}, "sha512-kJExsp4JCms7ipzg7SJ3y8DwmePaELHxKYtg+tZow+k0znUTf3cb+npgyqm8+ATZOdmfgfydIebPDWM172wfyA=="],
+
+    "@fastify/merge-json-schemas": ["@fastify/merge-json-schemas@0.2.1", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A=="],
+
+    "@fastify/proxy-addr": ["@fastify/proxy-addr@5.0.0", "", { "dependencies": { "@fastify/forwarded": "^3.0.0", "ipaddr.js": "^2.1.0" } }, "sha512-37qVVA1qZ5sgH7KpHkkC4z9SK6StIsIcOmpjvMPXNb3vx2GQxhZocogVYbr2PbbeLCQxYIPDok307xEvRZOzGA=="],
 
     "@floating-ui/core": ["@floating-ui/core@1.6.9", "", { "dependencies": { "@floating-ui/utils": "^0.2.9" } }, "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw=="],
 
@@ -1304,6 +1317,8 @@
 
     "@xyflow/system": ["@xyflow/system@0.0.51", "", { "dependencies": { "@types/d3-drag": "^3.0.7", "@types/d3-selection": "^3.0.10", "@types/d3-transition": "^3.0.8", "@types/d3-zoom": "^3.0.8", "d3-drag": "^3.0.0", "d3-selection": "^3.0.0", "d3-zoom": "^3.0.0" } }, "sha512-cYnuM3oWQQjx2Rdz0LdZCnbUaWZdZDiik20kPDYsa5SIlq++ZDIcKiDF6a93ncfMv9Ej5GWfDkouE7bObrdRqQ=="],
 
+    "abstract-logging": ["abstract-logging@2.0.1", "", {}, "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="],
+
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "acorn": ["acorn@8.14.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="],
@@ -1378,9 +1393,13 @@
 
     "async-retry": ["async-retry@1.3.3", "", { "dependencies": { "retry": "0.13.1" } }, "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw=="],
 
+    "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
+
     "autoprefixer": ["autoprefixer@10.4.20", "", { "dependencies": { "browserslist": "^4.23.3", "caniuse-lite": "^1.0.30001646", "fraction.js": "^4.3.7", "normalize-range": "^0.1.2", "picocolors": "^1.0.1", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.1.0" }, "bin": { "autoprefixer": "bin/autoprefixer" } }, "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g=="],
 
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
+
+    "avvio": ["avvio@9.1.0", "", { "dependencies": { "@fastify/error": "^4.0.0", "fastq": "^1.17.1" } }, "sha512-fYASnYi600CsH/j9EQov7lECAniYiBFiiAtBNuZYLA2leLe9qOvZzqYHFjtIj6gD2VMoMLP14834LFWvr4IfDw=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
@@ -1840,19 +1859,29 @@
 
     "external-editor": ["external-editor@3.1.0", "", { "dependencies": { "chardet": "^0.7.0", "iconv-lite": "^0.4.24", "tmp": "^0.0.33" } }, "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew=="],
 
+    "fast-decode-uri-component": ["fast-decode-uri-component@1.0.1", "", {}, "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
+    "fast-json-stringify": ["fast-json-stringify@6.0.1", "", { "dependencies": { "@fastify/merge-json-schemas": "^0.2.0", "ajv": "^8.12.0", "ajv-formats": "^3.0.1", "fast-uri": "^3.0.0", "json-schema-ref-resolver": "^2.0.0", "rfdc": "^1.2.0" } }, "sha512-s7SJE83QKBZwg54dIbD5rCtzOBVD43V1ReWXXYqBgwCwHLYAAT0RQc/FmrQglXqWPpz6omtryJQOau5jI4Nrvg=="],
+
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fast-querystring": ["fast-querystring@1.1.2", "", { "dependencies": { "fast-decode-uri-component": "^1.0.1" } }, "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg=="],
+
+    "fast-redact": ["fast-redact@3.5.0", "", {}, "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A=="],
 
     "fast-uri": ["fast-uri@3.0.6", "", {}, "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw=="],
 
     "fast-xml-parser": ["fast-xml-parser@4.5.3", "", { "dependencies": { "strnum": "^1.1.1" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig=="],
 
     "fastest-levenshtein": ["fastest-levenshtein@1.0.16", "", {}, "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg=="],
+
+    "fastify": ["fastify@5.3.2", "", { "dependencies": { "@fastify/ajv-compiler": "^4.0.0", "@fastify/error": "^4.0.0", "@fastify/fast-json-stringify-compiler": "^5.0.0", "@fastify/proxy-addr": "^5.0.0", "abstract-logging": "^2.0.1", "avvio": "^9.0.0", "fast-json-stringify": "^6.0.0", "find-my-way": "^9.0.0", "light-my-request": "^6.0.0", "pino": "^9.0.0", "process-warning": "^5.0.0", "rfdc": "^1.3.1", "secure-json-parse": "^4.0.0", "semver": "^7.6.0", "toad-cache": "^3.7.0" } }, "sha512-AIPqBgtqBAwkOkrnwesEE+dOyU30dQ4kh7udxeGVR05CRGwubZx+p2H8P0C4cRnQT0+EPK4VGea2DTL2RtWttg=="],
 
     "fastq": ["fastq@1.19.0", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA=="],
 
@@ -1871,6 +1900,8 @@
     "filter-obj": ["filter-obj@5.1.0", "", {}, "sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng=="],
 
     "finalhandler": ["finalhandler@2.1.0", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q=="],
+
+    "find-my-way": ["find-my-way@9.3.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-querystring": "^1.0.0", "safe-regex2": "^5.0.0" } }, "sha512-eRoFWQw+Yv2tuYlK2pjFS2jGXSxSppAs3hSQjfxVKxM5amECzIgYYc1FEI8ZmhSh/Ig+FrKEz43NLRKJjYCZVg=="],
 
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
@@ -2062,7 +2093,7 @@
 
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
 
-    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+    "ipaddr.js": ["ipaddr.js@2.2.0", "", {}, "sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA=="],
 
     "iron-webcrypto": ["iron-webcrypto@1.2.1", "", {}, "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg=="],
 
@@ -2242,6 +2273,8 @@
 
     "json-pointer": ["json-pointer@0.6.2", "", { "dependencies": { "foreach": "^2.0.4" } }, "sha512-vLWcKbOaXlO+jvRy4qNd+TI1QUPZzfJj1tpJ3vAXDych5XJf93ftpUKe5pKCrzyIIwgBJcOcCVRUfqQP25afBw=="],
 
+    "json-schema-ref-resolver": ["json-schema-ref-resolver@2.0.1", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-HG0SIB9X4J8bwbxCbnd5FfPEbcXAJYTi1pBJeP/QPON+w8ovSME8iRG+ElHNxZNX2Qh6eYn1GdzJFS4cDFfx0Q=="],
+
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
@@ -2285,6 +2318,8 @@
     "leven": ["leven@3.1.0", "", {}, "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="],
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
+    "light-my-request": ["light-my-request@6.6.0", "", { "dependencies": { "cookie": "^1.0.1", "process-warning": "^4.0.0", "set-cookie-parser": "^2.6.0" } }, "sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A=="],
 
     "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
 
@@ -2556,6 +2591,8 @@
 
     "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
 
+    "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
+
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
@@ -2666,6 +2703,12 @@
 
     "pify": ["pify@2.3.0", "", {}, "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="],
 
+    "pino": ["pino@9.6.0", "", { "dependencies": { "atomic-sleep": "^1.0.0", "fast-redact": "^3.1.1", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^4.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-i85pKRCt4qMjZ1+L7sy2Ag4t1atFcdbEt76+7iRJn1g2BvsnRMGu9p8pivl9fs63M2kF/A0OacFZhTub+m/qMg=="],
+
+    "pino-abstract-transport": ["pino-abstract-transport@2.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw=="],
+
+    "pino-std-serializers": ["pino-std-serializers@7.0.0", "", {}, "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA=="],
+
     "pirates": ["pirates@4.0.6", "", {}, "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg=="],
 
     "pixi.js": ["pixi.js@8.9.1", "", { "dependencies": { "@pixi/colord": "^2.9.6", "@types/css-font-loading-module": "^0.0.12", "@types/earcut": "^2.1.4", "@webgpu/types": "^0.1.40", "@xmldom/xmldom": "^0.8.10", "earcut": "^2.2.4", "eventemitter3": "^5.0.1", "gifuct-js": "^2.1.2", "ismobilejs": "^1.1.1", "parse-svg-path": "^0.1.2" } }, "sha512-2vF5Yu9WC/83ly2tCGkjb+ZGnrr+vlKtZezmD0AmJEQoYZO5nL94806l+PVcJBKW6qrF0YHtbh0ubb6CB7/8Rg=="],
@@ -2722,6 +2765,8 @@
 
     "prismjs": ["prismjs@1.30.0", "", {}, "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="],
 
+    "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
+
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
 
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
@@ -2745,6 +2790,8 @@
     "query-string": ["query-string@9.1.1", "", { "dependencies": { "decode-uri-component": "^0.4.1", "filter-obj": "^5.1.0", "split-on-first": "^3.0.0" } }, "sha512-MWkCOVIcJP9QSKU52Ngow6bsAWAPlPK2MludXvcrS2bGZSl+T1qX9MZvRIkqUIkGLJquMJHWfsT6eRqUpp4aWg=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
 
     "quick-lru": ["quick-lru@5.1.1", "", {}, "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="],
 
@@ -2789,6 +2836,8 @@
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
+
+    "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
 
     "recma-build-jsx": ["recma-build-jsx@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-util-build-jsx": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew=="],
 
@@ -2862,7 +2911,7 @@
 
     "restructure": ["restructure@3.0.2", "", {}, "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw=="],
 
-    "ret": ["ret@0.1.15", "", {}, "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="],
+    "ret": ["ret@0.5.0", "", {}, "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw=="],
 
     "retext": ["retext@9.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "retext-latin": "^4.0.0", "retext-stringify": "^4.0.0", "unified": "^11.0.0" } }, "sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA=="],
 
@@ -2875,6 +2924,8 @@
     "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
 
     "reusify": ["reusify@1.0.4", "", {}, "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="],
+
+    "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
 
     "rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
 
@@ -2896,6 +2947,10 @@
 
     "safe-regex-test": ["safe-regex-test@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-regex": "^1.2.1" } }, "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw=="],
 
+    "safe-regex2": ["safe-regex2@5.0.0", "", { "dependencies": { "ret": "~0.5.0" } }, "sha512-YwJwe5a51WlK7KbOJREPdjNrpViQBI3p4T50lfwPuDhZnE3XGVTlGvi+aolc5+RvxDD6bnUmjVsU9n1eboLUYw=="],
+
+    "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "sass-formatter": ["sass-formatter@0.7.9", "", { "dependencies": { "suf-log": "^2.5.3" } }, "sha512-CWZ8XiSim+fJVG0cFLStwDvft1VI7uvXdCNJYXhDvowiv+DsbD1nXLiQ4zrE5UBvj5DWZJ93cwN0NX5PMsr1Pw=="],
@@ -2903,6 +2958,8 @@
     "sax": ["sax@1.4.1", "", {}, "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="],
 
     "scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
+
+    "secure-json-parse": ["secure-json-parse@4.0.0", "", {}, "sha512-dxtLJO6sc35jWidmLxo7ij+Eg48PM/kleBsxpC8QJE0qJICe+KawkDQmvCMZUr9u7WKVHgMW6vy3fQ7zMiFZMA=="],
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
@@ -2967,6 +3024,8 @@
     "snake-case": ["snake-case@3.0.4", "", { "dependencies": { "dot-case": "^3.0.4", "tslib": "^2.0.3" } }, "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg=="],
 
     "snakecase-keys": ["snakecase-keys@8.0.1", "", { "dependencies": { "map-obj": "^4.1.0", "snake-case": "^3.0.4", "type-fest": "^4.15.0" } }, "sha512-Sj51kE1zC7zh6TDlNNz0/Jn1n5HiHdoQErxO8jLtnyrkJW/M5PrI7x05uDgY3BO7OUQYKCvmeMurW6BPUdwEOw=="],
+
+    "sonic-boom": ["sonic-boom@4.2.0", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww=="],
 
     "sort-object-keys": ["sort-object-keys@1.1.3", "", {}, "sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg=="],
 
@@ -3078,6 +3137,8 @@
 
     "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
 
+    "thread-stream": ["thread-stream@3.1.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A=="],
+
     "tiny-inflate": ["tiny-inflate@1.0.3", "", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
 
     "tiny-jsonc": ["tiny-jsonc@1.0.2", "", {}, "sha512-f5QDAfLq6zIVSyCZQZhhyl0QS6MvAyTxgz4X4x3+EoCktNWEYJ6PeoEA97fyb98njpBNNi88ybpD7m+BDFXaCw=="],
@@ -3099,6 +3160,8 @@
     "tmpl": ["tmpl@1.0.5", "", {}, "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "toad-cache": ["toad-cache@3.7.0", "", {}, "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw=="],
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
@@ -3650,6 +3713,8 @@
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "fastify/semver": ["semver@7.7.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="],
+
     "filelist/minimatch": ["minimatch@5.1.6", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g=="],
 
     "glob/minimatch": ["minimatch@10.0.1", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ=="],
@@ -3700,6 +3765,8 @@
 
     "jest-validate/camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
 
+    "light-my-request/process-warning": ["process-warning@4.0.1", "", {}, "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q=="],
+
     "lower-case/tslib": ["tslib@2.4.1", "", {}, "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="],
 
     "make-dir/semver": ["semver@7.7.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="],
@@ -3740,6 +3807,8 @@
 
     "pg/pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
 
+    "pino/process-warning": ["process-warning@4.0.1", "", {}, "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q=="],
+
     "pkg-dir/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
     "postcss/nanoid": ["nanoid@3.3.8", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w=="],
@@ -3753,6 +3822,10 @@
     "pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
+
+    "proxy-addr/ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "randexp/ret": ["ret@0.1.15", "", {}, "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="],
 
     "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 

--- a/packages/adapter-postgres/src/postgres-source.test.ts
+++ b/packages/adapter-postgres/src/postgres-source.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { watermarkFromTransaction } from "@rejot-dev/sync/sync-controller";
+import { watermarkFromTransaction } from "@rejot-dev/sync/legacy-sync-controller";
 
 import { PostgresSource } from "./postgres-source.ts";
 import type { PostgresClient } from "./util/postgres-client.ts";

--- a/packages/contract/logger/logger.test.ts
+++ b/packages/contract/logger/logger.test.ts
@@ -1,18 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { ILogger, LogLevel, type LogLine, NamespacedLogger, shouldLog } from "./logger.ts";
-
-class MockLogger extends ILogger {
-  public messages: LogLine[] = [];
-
-  init(): void {
-    this.messages = [];
-  }
-
-  log(logLine: LogLine): void {
-    this.messages.push(logLine);
-  }
-}
+import { LogLevel, MockLogger, NamespacedLogger, shouldLog } from "./logger.ts";
 
 describe("Logger", () => {
   test("MockLogger respects log levels", () => {

--- a/packages/contract/logger/logger.ts
+++ b/packages/contract/logger/logger.ts
@@ -395,3 +395,15 @@ function getNamespaceFromFilePath(namespace?: string): string | undefined {
 
   return namespace;
 }
+
+export class MockLogger extends ILogger {
+  public messages: LogLine[] = [];
+
+  init(): void {
+    this.messages = [];
+  }
+
+  log(logLine: LogLine): void {
+    this.messages.push(logLine);
+  }
+}

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -19,10 +19,10 @@
       "types": "./dist/src/manifest/validate-manifest.d.ts",
       "default": "./dist/src/manifest/validate-manifest.js"
     },
-    "./sync-controller": {
-      "bun": "./src/sync-controller.ts",
-      "types": "./dist/src/sync-controller.d.ts",
-      "default": "./dist/src/sync-controller.js"
+    "./legacy-sync-controller": {
+      "bun": "./src/legacy-sync-controller.ts",
+      "types": "./dist/src/legacy-sync-controller.d.ts",
+      "default": "./dist/src/legacy-sync-controller.js"
     },
     "./sync-controller-new": {
       "bun": "./src/sync-controller/sync-controller.ts",
@@ -60,6 +60,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@rejot-dev/contract": "*"
+    "@rejot-dev/contract": "*",
+    "fastify": "^5.3.2"
   }
 }

--- a/packages/sync/src/http-controller/bun-http-controller.ts
+++ b/packages/sync/src/http-controller/bun-http-controller.ts
@@ -1,0 +1,55 @@
+import { serve, type Server } from "bun";
+
+import { getLogger } from "@rejot-dev/contract/logger";
+
+import { HttpController, type ServerConfig } from "./http-controller.ts";
+
+const log = getLogger(import.meta.url);
+
+export class BunHttpController extends HttpController {
+  readonly #serverResolver = Promise.withResolvers<void>();
+
+  #server: Server | null = null;
+
+  constructor(config: ServerConfig) {
+    super(config);
+  }
+
+  get promise(): Promise<void> {
+    return this.#serverResolver.promise;
+  }
+
+  get assignedPort(): number {
+    if (!this.#server) {
+      throw new Error("Server is not listening");
+    }
+    return this.#server.port;
+  }
+
+  /**
+   * @returns A promise that resolves when the server has stopped serving, i.e. stop() is called.
+   */
+  start(): Promise<void> {
+    log.info(`Http controller starting on ${this.requestedHostname}:${this.requestedPort}`);
+
+    this.#server = serve({
+      port: this.requestedPort,
+      hostname: this.requestedHostname,
+      routes: this.routeHandlers.size > 0 ? this.createRoutes() : undefined,
+      reusePort: true,
+      fetch:
+        this.routeHandlers.size > 0 ? undefined : () => new Response("Not found", { status: 404 }),
+    });
+
+    return Promise.resolve();
+  }
+
+  async stop(): Promise<void> {
+    if (this.#server) {
+      await this.#server.stop();
+      this.#server = null;
+    }
+
+    this.#serverResolver.resolve();
+  }
+}

--- a/packages/sync/src/http-controller/fastify-http-controller.ts
+++ b/packages/sync/src/http-controller/fastify-http-controller.ts
@@ -1,0 +1,120 @@
+import { fastify, type FastifyInstance, type FastifyReply, type FastifyRequest } from "fastify";
+import { ZodError } from "zod";
+
+import { getLogger } from "@rejot-dev/contract/logger";
+
+import {
+  HttpController,
+  type RequestParams,
+  type RouteConfig,
+  type RouteHandler,
+  type ServerConfig,
+} from "./http-controller.ts";
+import { HTTPBadRequestError, HTTPBaseError } from "./http-service-errors.ts";
+
+const log = getLogger(import.meta.url);
+
+export class FastifyHttpController extends HttpController {
+  #fastify: FastifyInstance;
+
+  readonly #serverResolver = Promise.withResolvers<void>();
+
+  constructor(config: ServerConfig) {
+    super(config);
+
+    this.#fastify = fastify({ logger: false }); // Disable Fastify's built-in logger
+  }
+
+  get promise(): Promise<void> {
+    return this.#serverResolver.promise;
+  }
+
+  get assignedPort(): number {
+    const address = this.#fastify.server.address();
+
+    if (typeof address === "string" || address === null) {
+      throw new Error("Server is not listening");
+    }
+
+    return address.port;
+  }
+
+  async start(): Promise<void> {
+    for (const [routeConfig, originalHandler] of this.routeHandlers.entries()) {
+      this.registerRoute(routeConfig, originalHandler);
+      log.info(`Registered route ${routeConfig.method} ${routeConfig.path}`);
+    }
+
+    await this.#fastify.listen({ port: this.requestedPort, host: this.requestedHostname });
+    log.info(`Server listening on ${this.requestedHostname}:${this.assignedPort}`);
+  }
+
+  async stop(): Promise<void> {
+    await this.#fastify.close();
+    this.#serverResolver.resolve();
+  }
+
+  private registerRoute<T extends RouteConfig>(
+    routeConfig: T,
+    originalHandler: RouteHandler<T>,
+  ): void {
+    this.#fastify.route({
+      method: routeConfig.method,
+      url: routeConfig.path,
+      handler: async (request: FastifyRequest, reply: FastifyReply) => {
+        try {
+          const requestData = {} as RequestParams<T>;
+
+          // Parse Query Params if schema exists
+          if (routeConfig.queryParams) {
+            const url = `${request.protocol}://${request.hostname}${request.url}`;
+            requestData.queryParams = HttpController.parseQueryParams(url, routeConfig.queryParams);
+          }
+
+          // Parse JSON Body if schema exists
+          if (routeConfig.jsonBody) {
+            // Assumes Fastify has already parsed the body based on Content-Type
+            const parsedBody = routeConfig.jsonBody.safeParse(request.body);
+            if (!parsedBody.success) {
+              throw new HTTPBadRequestError(`Invalid JSON body: ${parsedBody.error.message}`);
+            }
+            requestData.jsonBody = parsedBody.data;
+          }
+
+          // Call the user-provided handler
+          const responseObject = await originalHandler(requestData);
+
+          // Validate the response before sending
+          const parsedResponse = routeConfig.response.safeParse(responseObject);
+          if (!parsedResponse.success) {
+            // Log the detailed error server-side
+            log.error(
+              "Zod validation error on RESPONSE object. Check handler return value.",
+              parsedResponse.error.format(),
+            );
+            // Send generic error to client
+            reply.code(500).send({ error: "Internal Server Error: Invalid response format" });
+            return;
+          }
+
+          // Send successful response
+          reply.send(parsedResponse.data);
+        } catch (error) {
+          if (error instanceof HTTPBaseError) {
+            reply.code(error.status).send({ error: error.message });
+          } else if (error instanceof ZodError) {
+            // Should primarily be caught by safeParse, but acts as a fallback
+            log.warn(
+              "Caught ZodError during request processing (likely request validation)",
+              error.format(),
+            );
+            reply.code(400).send({ error: "Bad Request", details: error.format() });
+          } else {
+            log.error("Unhandled internal server error", error);
+            reply.code(500).send({ error: "Internal Server Error" });
+          }
+        }
+      },
+    });
+  }
+}

--- a/packages/sync/src/http-controller/http-controller-impl.test.ts
+++ b/packages/sync/src/http-controller/http-controller-impl.test.ts
@@ -1,0 +1,453 @@
+import { describe, expect, test as bunTest } from "bun:test";
+
+import { z } from "zod";
+
+import { BunHttpController } from "./bun-http-controller.ts";
+import { FastifyHttpController } from "./fastify-http-controller.ts";
+import { type HttpController, type RouteConfig } from "./http-controller.ts";
+
+const TEST_HOSTNAME = "localhost";
+
+const test = bunTest.todoIf(process.env["SKIP_SYNC_HTTP_SERVICE_TESTS"] === "true");
+
+describe.each([
+  ["BunHttpController", BunHttpController],
+  ["FastifyHttpController", FastifyHttpController],
+])("%s", (_name, HttpController) => {
+  function createHttpController(): HttpController {
+    return new HttpController({ hostname: "localhost" });
+  }
+
+  describe("JSON body handling", () => {
+    const testRoute = {
+      method: "POST",
+      path: "/test-json",
+      jsonBody: z.object({
+        name: z.string(),
+        age: z.number(),
+      }),
+      response: z.object({
+        message: z.string(),
+      }),
+    } satisfies RouteConfig;
+
+    test("successfully handles valid JSON body", async () => {
+      // setLogger(new ConsoleLogger(LogLevel.TRACE));
+      const controller = createHttpController();
+      controller.createRequest(testRoute, async ({ jsonBody }) => {
+        expect(jsonBody).toEqual({ name: "Test User", age: 25 });
+        return { message: "Success" };
+      });
+
+      await controller.start();
+
+      const response = await fetch(
+        `http://${TEST_HOSTNAME}:${controller.assignedPort}${testRoute.path}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name: "Test User", age: 25 }),
+        },
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data).toEqual({ message: "Success" });
+
+      await controller.stop();
+    });
+
+    test("returns 400 for invalid JSON", async () => {
+      const controller = createHttpController();
+      controller.createRequest(testRoute, async () => ({ message: "Should not reach here" }));
+
+      await controller.start();
+
+      const response = await fetch(
+        `http://${TEST_HOSTNAME}:${controller.assignedPort}${testRoute.path}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: "invalid json",
+        },
+      );
+
+      expect(response.status).toBe(400);
+
+      await controller.stop();
+    });
+
+    test("returns 400 for JSON not matching schema", async () => {
+      const controller = createHttpController();
+      controller.createRequest(testRoute, async () => ({ message: "Should not reach here" }));
+
+      await controller.start();
+
+      const response = await fetch(
+        `http://${TEST_HOSTNAME}:${controller.assignedPort}${testRoute.path}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name: "Test User", age: "25" }), // age should be number
+        },
+      );
+
+      expect(response.status).toBe(400);
+
+      await controller.stop();
+    });
+  });
+
+  describe("Query parameters handling", () => {
+    const testRoute = {
+      method: "GET",
+      path: "/test-query",
+      queryParams: z.object({
+        search: z.string(),
+        limit: z.coerce.number().min(1).max(1000),
+      }),
+      response: z.object({
+        results: z.array(z.string()),
+      }),
+    } satisfies RouteConfig;
+
+    test("successfully handles valid query parameters", async () => {
+      const controller = createHttpController();
+      controller.createRequest(testRoute, async ({ queryParams }) => {
+        expect(queryParams).toEqual({ search: "test", limit: 5 });
+        return { results: ["test"] };
+      });
+
+      await controller.start();
+
+      const response = await fetch(
+        `http://${TEST_HOSTNAME}:${controller.assignedPort}${testRoute.path}?search=test&limit=5`,
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data).toEqual({ results: ["test"] });
+
+      await controller.stop();
+    });
+
+    test("returns 400 for missing required query parameters", async () => {
+      const controller = createHttpController();
+      controller.createRequest(testRoute, async () => ({ results: [] }));
+
+      await controller.start();
+
+      const response = await fetch(
+        `http://${TEST_HOSTNAME}:${controller.assignedPort}${testRoute.path}?search=test`,
+      ); // missing limit
+
+      expect(response.status).toBe(400);
+
+      await controller.stop();
+    });
+
+    test("returns 400 for invalid query parameters", async () => {
+      const controller = createHttpController();
+      controller.createRequest(testRoute, async () => ({ results: [] }));
+
+      await controller.start();
+
+      const response = await fetch(
+        `http://${TEST_HOSTNAME}:${controller.assignedPort}${testRoute.path}?search=test&limit=invalid`,
+      );
+
+      expect(response.status).toBe(400);
+
+      await controller.stop();
+    });
+
+    test("handles complex objects in query parameters", async () => {
+      const complexQueryRoute = {
+        method: "GET",
+        path: "/complex-query",
+        queryParams: z.object({
+          someNumber: z.coerce.number().min(1).max(100),
+          someString: z.string(),
+          data: z.object({
+            filters: z.array(
+              z.object({
+                field: z.string(),
+                operator: z.enum(["eq", "gt", "lt"]),
+                value: z.coerce.number(),
+              }),
+            ),
+            sort: z.object({
+              field: z.string(),
+              direction: z.enum(["asc", "desc"]),
+            }),
+          }),
+        }),
+        response: z.object({
+          applied: z.object({
+            filters: z.array(z.any()),
+            sort: z.any(),
+          }),
+        }),
+      } satisfies RouteConfig;
+
+      const controller = createHttpController();
+      controller.createRequest(complexQueryRoute, async ({ queryParams }) => {
+        console.log("queryParams", queryParams);
+        return {
+          applied: queryParams.data,
+        };
+      });
+
+      await controller.start();
+
+      const queryObject: z.infer<typeof complexQueryRoute.queryParams>["data"] = {
+        filters: [
+          { field: "age", operator: "gt", value: 25 },
+          { field: "score", operator: "eq", value: 100 },
+        ],
+        sort: { field: "name", direction: "asc" },
+      };
+
+      const queryString = new URLSearchParams({
+        someNumber: "10",
+        someString: "test",
+        data: JSON.stringify(queryObject),
+      }).toString();
+      console.log("queryString", queryString);
+
+      const response = await fetch(
+        `http://${TEST_HOSTNAME}:${controller.assignedPort}${complexQueryRoute.path}?${queryString}&wilco=123`,
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data).toEqual({
+        applied: queryObject,
+      });
+
+      await controller.stop();
+    });
+  });
+
+  describe("Response validation", () => {
+    const testRoute = {
+      method: "GET",
+      path: "/test-response",
+      response: z.object({
+        message: z.string(),
+      }),
+    } satisfies RouteConfig;
+
+    test("returns 500 for invalid response from handler", async () => {
+      const controller = createHttpController();
+      // Using type assertion to intentionally create an invalid response
+      controller.createRequest(testRoute, async () => ({
+        message: 123 as unknown as string,
+      }));
+
+      await controller.start();
+
+      const response = await fetch(
+        `http://${TEST_HOSTNAME}:${controller.assignedPort}${testRoute.path}`,
+      );
+
+      expect(response.status).toBe(500);
+
+      await controller.stop();
+    });
+  });
+
+  describe("Route handling", () => {
+    test("handles multiple routes", async () => {
+      const controller = createHttpController();
+      const route1 = {
+        method: "GET",
+        path: "/route1",
+        response: z.object({ message: z.string() }),
+      } satisfies RouteConfig;
+
+      const route2 = {
+        method: "POST",
+        path: "/route2",
+        jsonBody: z.object({ data: z.string() }),
+        response: z.object({ message: z.string() }),
+      } satisfies RouteConfig;
+
+      controller
+        .createRequest(route1, async () => ({ message: "route1" }))
+        .createRequest(route2, async () => ({ message: "route2" }));
+
+      await controller.start();
+
+      const response1 = await fetch(
+        `http://${TEST_HOSTNAME}:${controller.assignedPort}${route1.path}`,
+      );
+      expect(response1.status).toBe(200);
+      const data1 = await response1.json();
+      expect(data1).toEqual({ message: "route1" });
+
+      const response2 = await fetch(
+        `http://${TEST_HOSTNAME}:${controller.assignedPort}${route2.path}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ data: "test" }),
+        },
+      );
+      expect(response2.status).toBe(200);
+      const data2 = await response2.json();
+      expect(data2).toEqual({ message: "route2" });
+
+      await controller.stop();
+    });
+
+    test("returns 404 for unknown route", async () => {
+      const controller = createHttpController();
+      await controller.start();
+
+      const response = await fetch(`http://${TEST_HOSTNAME}:${controller.assignedPort}/unknown`);
+      expect(response.status).toBe(404);
+
+      await controller.stop();
+    });
+  });
+
+  describe("Optional parameters handling", () => {
+    test("handles route with no query params or json body", async () => {
+      const controller = createHttpController();
+      const simpleRoute = {
+        method: "GET",
+        path: "/simple",
+        response: z.object({ message: z.string() }),
+      } satisfies RouteConfig;
+
+      controller.createRequest(simpleRoute, async () => {
+        return { message: "simple response" };
+      });
+
+      await controller.start();
+
+      const response = await fetch(
+        `http://${TEST_HOSTNAME}:${controller.assignedPort}${simpleRoute.path}`,
+      );
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data).toEqual({ message: "simple response" });
+
+      await controller.stop();
+    });
+
+    test("handles route with only query params", async () => {
+      const controller = createHttpController();
+      const queryOnlyRoute = {
+        method: "GET",
+        path: "/query-only",
+        queryParams: z.object({ filter: z.string() }),
+        response: z.object({ filtered: z.string() }),
+      } satisfies RouteConfig;
+
+      controller.createRequest(queryOnlyRoute, async ({ queryParams }) => {
+        // TypeScript should know queryParams.filter exists and is string
+        return { filtered: `filtered by ${queryParams!.filter}` };
+      });
+
+      await controller.start();
+
+      const response = await fetch(
+        `http://${TEST_HOSTNAME}:${controller.assignedPort}${queryOnlyRoute.path}?filter=test`,
+      );
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data).toEqual({ filtered: "filtered by test" });
+
+      await controller.stop();
+    });
+
+    test("handles route with only json body", async () => {
+      const controller = createHttpController();
+      const jsonOnlyRoute = {
+        method: "POST",
+        path: "/json-only",
+        jsonBody: z.object({ data: z.string() }),
+        response: z.object({ processed: z.string() }),
+      } satisfies RouteConfig;
+
+      controller.createRequest(jsonOnlyRoute, async ({ jsonBody }) => {
+        // TypeScript should know jsonBody.data exists and is string
+        return { processed: `processed ${jsonBody!.data}` };
+      });
+
+      await controller.start();
+
+      const response = await fetch(
+        `http://${TEST_HOSTNAME}:${controller.assignedPort}${jsonOnlyRoute.path}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ data: "test data" }),
+        },
+      );
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data).toEqual({ processed: "processed test data" });
+
+      await controller.stop();
+    });
+
+    test("ignores query params when schema not defined", async () => {
+      const controller = createHttpController();
+      const noQueryParamsRoute = {
+        method: "GET",
+        path: "/no-query",
+        response: z.object({ message: z.string() }),
+      } satisfies RouteConfig;
+
+      controller.createRequest(noQueryParamsRoute, async () => {
+        return { message: "ok" };
+      });
+
+      await controller.start();
+
+      // Should work even with query params present
+      const response = await fetch(
+        `http://${TEST_HOSTNAME}:${controller.assignedPort}${noQueryParamsRoute.path}?unused=param`,
+      );
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data).toEqual({ message: "ok" });
+
+      await controller.stop();
+    });
+
+    test("rejects json body when schema not defined", async () => {
+      const controller = createHttpController();
+      const noJsonBodyRoute = {
+        method: "POST",
+        path: "/no-json",
+        response: z.object({ message: z.string() }),
+      } satisfies RouteConfig;
+
+      controller.createRequest(noJsonBodyRoute, async () => {
+        return { message: "ok" };
+      });
+
+      await controller.start();
+
+      const response = await fetch(
+        `http://${TEST_HOSTNAME}:${controller.assignedPort}${noJsonBodyRoute.path}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ some: "data" }),
+        },
+      );
+
+      // Since no JSON body schema is defined, the request should be handled without parsing the body
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data).toEqual({ message: "ok" });
+
+      await controller.stop();
+    });
+  });
+});

--- a/packages/sync/src/legacy-sync-controller.test.ts
+++ b/packages/sync/src/legacy-sync-controller.test.ts
@@ -8,7 +8,7 @@ import type {
   TransformedOperation,
 } from "@rejot-dev/contract/sync";
 
-import { SyncController } from "./sync-controller.ts";
+import { LegacySyncController } from "./legacy-sync-controller.ts";
 
 function createWatermarkTransaction(type: "low" | "high", backfillId: string): Transaction {
   return {
@@ -121,7 +121,7 @@ describe("Simple Sync Controller Operations", () => {
   test("insert operation", async () => {
     const sink = new TestSink();
     const source = new TestSource();
-    const syncController = new SyncController({ source, sink });
+    const syncController = new LegacySyncController({ source, sink });
     await syncController.prepare();
     await syncController.start();
 
@@ -148,7 +148,7 @@ describe("Simple Sync Controller Operations", () => {
   test("update operation", async () => {
     const sink = new TestSink();
     const source = new TestSource();
-    const syncController = new SyncController({ source, sink });
+    const syncController = new LegacySyncController({ source, sink });
     await syncController.prepare();
     await syncController.start();
 
@@ -175,7 +175,7 @@ describe("Simple Sync Controller Operations", () => {
   test("delete operation", async () => {
     const sink = new TestSink();
     const source = new TestSource();
-    const syncController = new SyncController({ source, sink });
+    const syncController = new LegacySyncController({ source, sink });
     await syncController.prepare();
     await syncController.start();
 
@@ -210,7 +210,7 @@ describe("Backfills for Sync Controller", () => {
       { id: 3, name: "c" },
     ];
 
-    const syncController = new SyncController({ source, sink });
+    const syncController = new LegacySyncController({ source, sink });
     await syncController.prepare();
     await syncController.start();
 
@@ -291,7 +291,7 @@ describe("Backfills for Sync Controller", () => {
       { pkeya: 3, pkeyb: 3, name: "c" },
     ];
 
-    const syncController = new SyncController({ source, sink });
+    const syncController = new LegacySyncController({ source, sink });
     await syncController.prepare();
     await syncController.start();
 
@@ -340,7 +340,7 @@ describe("Backfills for Sync Controller", () => {
       { address_id: 3, user_id: 3, name: "backfill" },
     ];
 
-    const syncController = new SyncController({ source, sink });
+    const syncController = new LegacySyncController({ source, sink });
     await syncController.prepare();
     await syncController.start();
 
@@ -406,7 +406,7 @@ describe("Backfills for Sync Controller", () => {
       { id: 2, name: "backfill" },
     ];
 
-    const syncController = new SyncController({ source, sink });
+    const syncController = new LegacySyncController({ source, sink });
     await syncController.prepare();
     await syncController.start();
 
@@ -467,7 +467,7 @@ describe("Backfills for Sync Controller", () => {
     const sink = new TestSink();
     const source = new TestSource();
 
-    const syncController = new SyncController({ source, sink });
+    const syncController = new LegacySyncController({ source, sink });
     await syncController.prepare();
     await syncController.start();
 
@@ -488,7 +488,7 @@ describe("Backfills for Sync Controller", () => {
   test("sequential backfills", async () => {
     const sink = new TestSink();
     const source = new TestSource();
-    const syncController = new SyncController({ source, sink });
+    const syncController = new LegacySyncController({ source, sink });
 
     await syncController.prepare();
     await syncController.start();
@@ -534,7 +534,7 @@ describe("Backfills for Sync Controller", () => {
   test("backfill times out", async () => {
     const sink = new TestSink();
     const source = new TestSource();
-    const syncController = new SyncController({ source, sink, backfillTimeoutMs: 1 });
+    const syncController = new LegacySyncController({ source, sink, backfillTimeoutMs: 1 });
 
     await syncController.prepare();
     await syncController.start();

--- a/packages/sync/src/legacy-sync-controller.ts
+++ b/packages/sync/src/legacy-sync-controller.ts
@@ -11,6 +11,8 @@ import type {
 import { type BackfillSource, ResultSetStore } from "./result-set-store.ts";
 import { DEFAULT_BACKFILL_TIMEOUT_MS } from "./sync-consts.ts";
 
+// TODO(Wilco): This should be removed, but it has an implementation for backfills we still need to port.
+
 const log = getLogger(import.meta.url);
 
 type SyncControllerConfig = {
@@ -56,7 +58,7 @@ function recordToPublicSchemaOperation(
   };
 }
 
-export class SyncController {
+export class LegacySyncController {
   #source: IDataSource;
   #sink: IDataSink;
 

--- a/packages/sync/src/sync-controller/sync-controller.test.ts
+++ b/packages/sync/src/sync-controller/sync-controller.test.ts
@@ -110,6 +110,8 @@ describe("SyncController", () => {
     await controller.prepare();
     const controllerPromise = controller.start();
 
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
     // Stop immediately
     await controller.stop();
     await controller.close();

--- a/packages/sync/src/sync-controller/sync-controller.ts
+++ b/packages/sync/src/sync-controller/sync-controller.ts
@@ -87,11 +87,15 @@ export class SyncController implements ISyncController {
   }
 
   async start() {
+    log.debug("hello world");
+
     this.state = "started";
+    await this.#httpController?.start();
+
+    log.debug("SyncController start race");
     await Promise.race([
       this.#startIterateSourceReader(),
       ...this.#subscribeMessageBuses.map((bus) => this.#startIterateSubscribeMessageBus(bus)),
-      this.#httpController?.start(),
     ]);
     log.debug("SyncController start race finished, stopping.");
     await this.stop();

--- a/packages/sync/src/sync-http-service/sync-http-service.ts
+++ b/packages/sync/src/sync-http-service/sync-http-service.ts
@@ -1,5 +1,6 @@
 import type { IEventStore } from "@rejot-dev/contract/event-store";
 
+import { FastifyHttpController } from "../http-controller/fastify-http-controller.ts";
 import { HttpController } from "../http-controller/http-controller.ts";
 import type { ISyncController } from "../sync-controller/sync-controller.ts";
 import {
@@ -27,7 +28,7 @@ export class SyncHTTPController implements ISyncHTTPController {
   constructor(config: ServerConfig, syncController: ISyncController, eventStore: IEventStore) {
     this.#syncController = syncController;
 
-    this.#httpController = new HttpController(config);
+    this.#httpController = new FastifyHttpController(config);
     this.#httpController.createRequest(indexRoute, async () => {
       return {
         health: "ok" as const,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Replaced the Bun-based HTTP controller in the sync package with a new Fastify-based implementation for improved flexibility and compatibility.

- **Dependencies**
  - Added Fastify as a dependency in the sync package.

- **Refactors**
  - Introduced `FastifyHttpController` and updated all sync HTTP service code and tests to use it.
  - Moved the old Bun controller to a separate file for legacy support.
  - Updated imports and test files to use the new controller structure.

<!-- End of auto-generated description by mrge. -->

