### PR TITLE
Lint: extend .ts extension rule to exports

### DIFF
--- a/packages/contract-tools/manifest/index.ts
+++ b/packages/contract-tools/manifest/index.ts
@@ -4,10 +4,10 @@ export {
   readManifestOrGetEmpty,
   writeManifest,
 } from "./manifest.fs";
-export { ManifestPrinter } from "./manifest-printer";
+export { ManifestPrinter } from "./manifest-printer.ts";
 export type {
   IManifestWorkspaceResolver,
   ManifestInfo,
   ResolveWorkspaceOptions,
-} from "./manifest-workspace-resolver";
-export { ManifestWorkspaceResolver } from "./manifest-workspace-resolver";
+} from "./manifest-workspace-resolver.ts";
+export { ManifestWorkspaceResolver } from "./manifest-workspace-resolver.ts";

--- a/packages/contract/event-store/event-store.ts
+++ b/packages/contract/event-store/event-store.ts
@@ -61,4 +61,4 @@ export interface IEventStore {
   read(cursors: Cursor[], limit?: number): Promise<OperationMessage[]>;
 }
 
-export { InMemoryEventStore } from "./in-memory-event-store";
+export { InMemoryEventStore } from "./in-memory-event-store.ts";

--- a/packages/sqlparser/index.ts
+++ b/packages/sqlparser/index.ts
@@ -51,4 +51,4 @@ export function findPlaceholders(statements: Statement[]): PlaceholderInfo[] {
 }
 
 // Re-export all types
-export * from "./types";
+export * from "./types.ts";

--- a/scripts/eslint-plugin-local-import-check.mjs
+++ b/scripts/eslint-plugin-local-import-check.mjs
@@ -135,8 +135,7 @@ const relativeImportExtensionRule = {
   meta: {
     type: "problem",
     docs: {
-      description: "Force relative import paths to include `.ts`",
-      recommended: false,
+      description: "Force relative import and export paths to include `.ts`",
     },
     fixable: "code",
     schema: [],
@@ -154,7 +153,7 @@ const relativeImportExtensionRule = {
       if (isRelative && !hasExt) {
         context.report({
           node: literal,
-          message: "Add '.ts' extension to relative import '{{path}}'",
+          message: "Add '.ts' extension to relative path '{{path}}'",
           data: { path: value },
           fix(fixer) {
             return fixer.replaceText(literal, `'${value}.ts'`);
@@ -165,6 +164,12 @@ const relativeImportExtensionRule = {
 
     return {
       ImportDeclaration(node) {
+        if (node.source?.type === "Literal") checkLiteral(node.source);
+      },
+      ExportAllDeclaration(node) {
+        if (node.source?.type === "Literal") checkLiteral(node.source);
+      },
+      ExportNamedDeclaration(node) {
         if (node.source?.type === "Literal") checkLiteral(node.source);
       },
     };


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Updated the lint rule to require .ts extensions on both import and export paths. Fixed all export statements in the codebase to use .ts extensions.

<!-- End of auto-generated description by mrge. -->

