### PR TITLE
Automatically add a rejot-cli script to the path in the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,15 @@ FROM base AS release
 WORKDIR /opt
 USER bun
 
-COPY --from=install /install/node_modules /opt/node_modules 
+COPY --from=install /install/node_modules /opt/node_modules
 COPY . /opt
 COPY entrypoint.sh /entrypoint.sh
+
+USER root
+RUN if [ "${REJOT_APP}" = "rejot-cli" ]; then \
+    echo '#!/bin/bash\nexec bun run /opt/apps/rejot-cli/bin/run.js "$@"' > /usr/local/bin/rejot-cli && \
+    chmod +x /usr/local/bin/rejot-cli; \
+    fi
+USER bun
 
 ENTRYPOINT [ "/entrypoint.sh" ]


### PR DESCRIPTION
Handy when playing around with the cli inside a docker container, instead of spinning up an entire container for 1 command.
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Added a script to the Docker image so you can run rejot-cli directly from the command line inside the container. This makes it easier to use the CLI without extra setup.

<!-- End of auto-generated description by mrge. -->

