### PR TITLE
Manifest: add $schema key in order to self-describe the schema

### DIFF
--- a/packages/contract-tools/manifest/manifest.fs.ts
+++ b/packages/contract-tools/manifest/manifest.fs.ts
@@ -101,6 +101,16 @@ export async function findManifestPath(
   }
 }
 
+async function findContractPackageVersion(): Promise<string | null> {
+  try {
+    // @ts-expect-error: dynamic import
+    const pkg = (await import("@rejot-dev/contract/package.json")) as { version?: string };
+    return pkg.version || null;
+  } catch (_e) {
+    return null;
+  }
+}
+
 export async function writeManifest(manifest: Manifest, path: string) {
   await mkdir(dirname(path), { recursive: true });
   await writeFile(path, JSON.stringify(manifest, null, 2));
@@ -198,6 +208,11 @@ export async function initManifest(
     slug,
     manifestVersion: CURRENT_MANIFEST_FILE_VERSION,
   };
+
+  const contractVersion = await findContractPackageVersion();
+  if (contractVersion) {
+    manifest.$schema = `https://unpkg.com/@rejot-dev/contract@${contractVersion}/schema.json`;
+  }
 
   if (options.workspace) {
     manifest.workspaces = [];

--- a/packages/contract/manifest/manifest.ts
+++ b/packages/contract/manifest/manifest.ts
@@ -142,6 +142,7 @@ export const SyncManifestSchema = z.object({
     ),
   /** Version of the manifest file format. */
   manifestVersion: z.number().describe("Version of the manifest file format."),
+  $schema: z.string().optional().describe("URL for the self-describing JSON schema."),
 
   connections: z.array(ConnectionSchema).optional(),
   dataStores: z.array(DataStoreSchema).optional(),

--- a/packages/contract/schema.json
+++ b/packages/contract/schema.json
@@ -9,6 +9,10 @@
       "type": "number",
       "description": "Version of the manifest file format."
     },
+    "$schema": {
+      "type": "string",
+      "description": "URL for the self-describing JSON schema."
+    },
     "connections": {
       "type": "array",
       "items": {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Added a $schema key to the manifest to include a URL pointing to its JSON schema for self-description.

- **New Features**
  - The manifest now includes a $schema field with a versioned schema URL.
  - Updated schema and validation to support the new $schema field.

<!-- End of auto-generated description by mrge. -->

