### PR TITLE
Logs: only format elapsed time in tty, iso8601 otherwise

### DIFF
--- a/packages/contract/logger/logger.ts
+++ b/packages/contract/logger/logger.ts
@@ -1,3 +1,5 @@
+import process from "node:process";
+
 import fs from "fs";
 import { fileURLToPath } from "url";
 
@@ -231,8 +233,10 @@ export class ConsoleLogger extends ILogger {
       return;
     }
 
-    // Override the timestamp part with elapsed time
-    let logMessage = `[${logLevelToStringPadded(type)}] ${this.formatElapsedTime()} [${(namespace ?? "").padEnd(longestNamespaceLengthSeen)}] ${message}`;
+    const timestamp = process.stdout.isTTY ? this.formatElapsedTime() : new Date().toISOString();
+    const namespaceString = (namespace ?? "").padEnd(longestNamespaceLengthSeen);
+
+    let logMessage = `[${logLevelToStringPadded(type)}] ${timestamp} [${namespaceString}] ${message}`;
 
     if (args && args.length > 0) {
       const serializedArgs = args.map(serializeArg);


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Logger now shows elapsed time in TTY terminals and ISO8601 timestamps otherwise for clearer log output.

<!-- End of auto-generated description by mrge. -->

