### PR TITLE
Integration-test: introduce 'one'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ COPY packages/contract/package.json packages/contract/package.json
 COPY packages/contract-tools/package.json packages/contract-tools/package.json
 COPY packages/sync/package.json packages/sync/package.json
 COPY packages/sqlparser/package.json packages/sqlparser/package.json
+COPY integration-tests/one/package.json integration-tests/one/package.json
 
 RUN bun install --filter ./apps/${REJOT_APP} --production --no-progress \
   || (echo "Hint: On lockfile is frozen error, ensure all workspace package.json files are copied into the Dockerfile!" && exit 1)

--- a/apps/rejot-cli/src/commands/manifest-datastore/manifest-datastore.command.test.ts
+++ b/apps/rejot-cli/src/commands/manifest-datastore/manifest-datastore.command.test.ts
@@ -106,7 +106,7 @@ describe("ManifestDataStore commands", () => {
     test("list all datastores", async () => {
       // Add some test datastores
       await runCommand(
-        `manifest:datastore:add --manifest ${manifestPath} --connection test-connection --publication test-pub1 --slot test-slot1`,
+        `manifest:datastore:add --manifest ${manifestPath} --connection test-connection --publication test_pub1 --slot test_slot1`,
       );
 
       // Capture console output
@@ -123,7 +123,7 @@ describe("ManifestDataStore commands", () => {
 
       expect(logString).toContain("Data Stores");
       expect(logString).toContain("test-connection");
-      expect(logString).toContain("test-pub1");
+      expect(logString).toContain("test_pub1");
     });
   });
 });

--- a/bun.lock
+++ b/bun.lock
@@ -123,7 +123,7 @@
     },
     "apps/mcp": {
       "name": "@rejot-dev/mcp",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "bin": {
         "rejot-mcp": "./index.ts",
       },
@@ -146,16 +146,16 @@
     },
     "apps/rejot-cli": {
       "name": "@rejot-dev/cli",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "bin": {
         "rejot-cli": "./bin/run.js",
       },
       "dependencies": {
         "@oclif/core": "^4.2.8",
-        "@rejot-dev/adapter-postgres": "*",
-        "@rejot-dev/contract": "*",
-        "@rejot-dev/contract-tools": "*",
-        "@rejot-dev/sync": "*",
+        "@rejot-dev/adapter-postgres": "workspace:*",
+        "@rejot-dev/contract": "workspace:*",
+        "@rejot-dev/contract-tools": "workspace:*",
+        "@rejot-dev/sync": "workspace:*",
         "@types/debug": "^4.1.12",
         "debug": "^4.4.0",
         "oclif": "^4.17.34",
@@ -198,13 +198,31 @@
         "typescript": "^5.7.2",
       },
     },
+    "integration-tests/one": {
+      "name": "@rejot-dev/integration-tests-one",
+      "dependencies": {
+        "@rejot-dev/adapter-postgres": "workspace:*",
+        "@rejot-dev/cli": "workspace:*",
+        "@rejot-dev/contract": "workspace:*",
+        "@rejot-dev/contract-tools": "workspace:*",
+        "@rejot-dev/sync": "workspace:*",
+        "pg": "^8.11.3",
+        "zod": "^3.24.2",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+      },
+      "peerDependencies": {
+        "typescript": "^5",
+      },
+    },
     "packages/adapter-postgres": {
       "name": "@rejot-dev/adapter-postgres",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "dependencies": {
-        "@rejot-dev/contract": "*",
-        "@rejot-dev/sqlparser": "*",
-        "@rejot-dev/sync": "*",
+        "@rejot-dev/contract": "workspace:*",
+        "@rejot-dev/sqlparser": "workspace:*",
+        "@rejot-dev/sync": "workspace:*",
         "pg": "^8.11.3",
         "pg-logical-replication": "^2.0.7",
       },
@@ -222,7 +240,7 @@
     },
     "packages/contract": {
       "name": "@rejot-dev/contract",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
@@ -232,25 +250,25 @@
     },
     "packages/contract-tools": {
       "name": "@rejot-dev/contract-tools",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "dependencies": {
-        "@rejot-dev/contract": "*",
+        "@rejot-dev/contract": "workspace:*",
         "esbuild": "^0.25.3",
         "glob": "^11.0.1",
       },
     },
     "packages/sqlparser": {
       "name": "@rejot-dev/sqlparser",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "dependencies": {
         "@rejot-dev/sqlparser-wasm": "^0.1.0",
       },
     },
     "packages/sync": {
       "name": "@rejot-dev/sync",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "dependencies": {
-        "@rejot-dev/contract": "*",
+        "@rejot-dev/contract": "workspace:*",
         "fastify": "^5.3.2",
       },
     },
@@ -946,6 +964,8 @@
 
     "@rejot-dev/controller": ["@rejot-dev/controller@workspace:apps/controller"],
 
+    "@rejot-dev/integration-tests-one": ["@rejot-dev/integration-tests-one@workspace:integration-tests/one"],
+
     "@rejot-dev/mcp": ["@rejot-dev/mcp@workspace:apps/mcp"],
 
     "@rejot-dev/sqlparser": ["@rejot-dev/sqlparser@workspace:packages/sqlparser"],
@@ -1156,7 +1176,7 @@
 
     "@types/better-sqlite3": ["@types/better-sqlite3@7.6.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-fnQmj8lELIj7BSrZQAdBMHEHX8OZLYIHXqAKT1O7tDfLxaINzf00PMjw22r3N/xXh0w/sGHlO6SVaCQ2mj78lg=="],
 
-    "@types/bun": ["@types/bun@1.2.4", "", { "dependencies": { "bun-types": "1.2.4" } }, "sha512-QtuV5OMR8/rdKJs213iwXDpfVvnskPXY/S0ZiFbsTjQZycuqPbMW8Gf/XhLfwE5njW8sxI2WjISURXPlHypMFA=="],
+    "@types/bun": ["@types/bun@1.2.11", "", { "dependencies": { "bun-types": "1.2.11" } }, "sha512-ZLbbI91EmmGwlWTRWuV6J19IUiUC5YQ3TCEuSHI3usIP75kuoA8/0PVF+LTrbEnVc8JIhpElWOxv1ocI1fJBbw=="],
 
     "@types/cheerio": ["@types/cheerio@0.22.35", "", { "dependencies": { "@types/node": "*" } }, "sha512-yD57BchKRvTV+JD53UZ6PD8KWY5g5rvvMLRnZR3EQBCZXiDT/HR+pKpMzFGlWNhFrXlo7VPZXtKvIEwZkAWOIA=="],
 
@@ -1468,7 +1488,7 @@
 
     "builtin-modules": ["builtin-modules@5.0.0", "", {}, "sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg=="],
 
-    "bun-types": ["bun-types@1.2.4", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-nDPymR207ZZEoWD4AavvEaa/KZe/qlrbMSchqpQwovPZCKc7pwMoENjEtHgMKaAjJhy+x6vfqSBA1QU3bJgs0Q=="],
+    "bun-types": ["bun-types@1.2.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-dbkp5Lo8HDrXkLrONm6bk+yiiYQSntvFUzQp0v3pzTAsXk6FtgVMjdQ+lzFNVAmQFUkPQZ3WMZqH5tTo+Dp/IA=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
@@ -3640,6 +3660,8 @@
 
     "@radix-ui/react-tooltip/@radix-ui/react-slot": ["@radix-ui/react-slot@1.1.2", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ=="],
 
+    "@rejot-dev/cli/@types/node": ["@types/node@22.14.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw=="],
+
     "@rejot-dev/controller/@types/bun": ["@types/bun@1.2.9", "", { "dependencies": { "bun-types": "1.2.9" } }, "sha512-epShhLGQYc4Bv/aceHbmBhOz1XgUnuTZgcxjxk+WXwNyDXavv5QHD1QEFV0FwbTSQtNq6g4ZcV6y0vZakTjswg=="],
 
     "@rejot-dev/controller/@types/node": ["@types/node@22.14.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw=="],
@@ -3691,6 +3713,8 @@
     "boxen/widest-line": ["widest-line@5.0.0", "", { "dependencies": { "string-width": "^7.0.0" } }, "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA=="],
 
     "boxen/wrap-ansi": ["wrap-ansi@9.0.0", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q=="],
+
+    "bun-types/@types/node": ["@types/node@22.14.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw=="],
 
     "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
@@ -4112,6 +4136,8 @@
 
     "@radix-ui/react-tabs/@radix-ui/react-use-controllable-state/@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg=="],
 
+    "@rejot-dev/cli/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
     "@rejot-dev/controller/@types/bun/bun-types": ["bun-types@1.2.9", "", { "dependencies": { "@types/node": "*", "@types/ws": "*" } }, "sha512-dk/kOEfQbajENN/D6FyiSgOKEuUi9PWfqKQJEgwKrCMWbjS/S6tEXp178mWvWAcUSYm9ArDlWHZKO3T/4cLXiw=="],
 
     "@rejot-dev/controller/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
@@ -4159,6 +4185,8 @@
     "boxen/wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
 
     "boxen/wrap-ansi/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
+
+    "bun-types/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "drizzle-kit/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.19.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA=="],
 

--- a/integration-tests/one/.env.example
+++ b/integration-tests/one/.env.example
@@ -1,0 +1,2 @@
+# Rename .env.test
+REJOT_SYNC_CLI_TEST_CONNECTION=postgresql://postgres:postgres@localhost:5432/test

--- a/integration-tests/one/.gitignore
+++ b/integration-tests/one/.gitignore
@@ -1,0 +1,3 @@
+# only used for local tests, but bun doesn't load .env.local during tests
+.env.test
+rejot-manifest.json

--- a/integration-tests/one/README.md
+++ b/integration-tests/one/README.md
@@ -1,0 +1,16 @@
+# one
+
+To install dependencies:
+
+```bash
+bun install
+```
+
+To run:
+
+```bash
+bun run index.ts
+```
+
+This project was created using `bun init` in bun v1.2.10. [Bun](https://bun.sh) is a fast all-in-one
+JavaScript runtime.

--- a/integration-tests/one/one.test.ts
+++ b/integration-tests/one/one.test.ts
@@ -1,0 +1,193 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+import { $ } from "bun";
+import { rm } from "fs/promises";
+
+import {
+  parsePostgresConnectionString,
+  PostgresClient,
+} from "@rejot-dev/adapter-postgres/postgres-client";
+import { readManifest } from "@rejot-dev/contract-tools/manifest/manifest.fs";
+
+import {
+  pollForResult,
+  printSyncProcessOutput,
+  waitForProcessExitOrTimeout,
+} from "./test-helpers.ts";
+
+describe("Integration Test - One", () => {
+  let connectionString: string;
+  let client: PostgresClient;
+  let shouldCleanUp = true;
+
+  beforeAll(async () => {
+    // Get connection string.
+    if (!process.env["REJOT_SYNC_CLI_TEST_CONNECTION"]) {
+      throw new Error("REJOT_SYNC_CLI_TEST_CONNECTION is not set");
+    }
+    await rm("rejot-manifest.json", { force: true });
+
+    connectionString = process.env["REJOT_SYNC_CLI_TEST_CONNECTION"];
+
+    shouldCleanUp = !process.env["NO_CLEANUP"];
+
+    // Create the test schema and tables
+    const postgresConfig = parsePostgresConnectionString(connectionString);
+    client = PostgresClient.fromConfig(postgresConfig);
+    await client.connect();
+
+    try {
+      await client.query(
+        `DELETE FROM rejot_data_store.public_schema_state WHERE manifest_slug = '@rejot-dev/integration-tests-one'`,
+      );
+    } catch {
+      // ignore if the table doesn't exist
+    }
+
+    await client.tx(async (tx) => {
+      await tx.query(`DROP SCHEMA IF EXISTS rejot_integration_tests_one CASCADE`);
+      await tx.query(`DROP PUBLICATION IF EXISTS rejot_integration_tests_one`);
+
+      const hasReplicationSlot = await tx.query(
+        `SELECT EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = 'rejot_integration_tests_one_data_store')`,
+      );
+
+      if (hasReplicationSlot.rows[0]["exists"]) {
+        await tx.query(`SELECT pg_drop_replication_slot('rejot_integration_tests_one_data_store')`);
+      }
+
+      await tx.query(`CREATE SCHEMA rejot_integration_tests_one`);
+      await tx.query(
+        `
+        CREATE TABLE rejot_integration_tests_one.person (
+          id SERIAL PRIMARY KEY,
+          first_name TEXT,
+          last_name TEXT
+        )
+        `,
+      );
+      await tx.query(
+        `
+        CREATE TABLE rejot_integration_tests_one.person_email (
+          id SERIAL PRIMARY KEY,
+          person_id INTEGER REFERENCES rejot_integration_tests_one.person(id) ON DELETE CASCADE,
+          email TEXT
+        )
+        `,
+      );
+
+      await tx.query(
+        `
+        CREATE TABLE rejot_integration_tests_one.destination_person_email (
+          id SERIAL PRIMARY KEY,
+          name TEXT,
+          emails TEXT
+        )
+        `,
+      );
+    });
+  });
+
+  afterAll(async () => {
+    if (shouldCleanUp) {
+      await rm("rejot-manifest.json", { force: true });
+
+      await client.tx(async (tx) => {
+        await tx.query(`DROP SCHEMA IF EXISTS rejot_integration_tests_one CASCADE`);
+        await tx.query(`DROP PUBLICATION IF EXISTS rejot_integration_tests_one`);
+        await tx.query(`SELECT pg_drop_replication_slot('rejot_integration_tests_one_data_store')`);
+      });
+    } else {
+      const manifest = await readManifest("rejot-manifest.json");
+      console.dir(manifest, { depth: null });
+      console.log("  (skipped cleanup)");
+    }
+
+    await client.end();
+  });
+
+  test("Initialize Manifest", async () => {
+    const manifest =
+      await $`bunx rejot-cli manifest init --slug @rejot-dev/integration-tests-one`.text();
+    expect(manifest).toBeDefined();
+  });
+
+  test("Add a database connection", async () => {
+    const connector =
+      await $`bunx rejot-cli manifest connection add --slug main-connection --connection-string ${connectionString}`.text();
+    expect(connector).toBeDefined();
+  });
+
+  test("Add a data store", async () => {
+    const dataStore =
+      await $`bunx rejot-cli manifest datastore add --connection main-connection --publication rejot_integration_tests_one --slot rejot_integration_tests_one_data_store`.text();
+    expect(dataStore).toBeDefined();
+  });
+
+  test("Add an event store", async () => {
+    const eventStore =
+      await $`bunx rejot-cli manifest eventstore add --connection main-connection`.text();
+    expect(eventStore).toBeDefined();
+  });
+
+  test("Collect Schemas", async () => {
+    const collect =
+      await $`bunx rejot-cli collect --print --check --write schemas/one-schema.ts`.text();
+    expect(collect).toContain("Successfully validated 1 schema pairs.");
+  });
+
+  test(
+    "Sync Data",
+    async () => {
+      // Start the sync process in the background
+      const syncProcess = Bun.spawn({
+        cmd: [
+          "bunx",
+          "rejot-cli",
+          "manifest",
+          "sync",
+          "--log-level=trace",
+          "./rejot-manifest.json",
+        ],
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      try {
+        // Insert a person and two emails in a single transaction
+        await client.tx(async (tx) => {
+          const personResult = await tx.query(
+            `INSERT INTO rejot_integration_tests_one.person (first_name, last_name) VALUES ($1, $2) RETURNING id`,
+            ["Alice", "Smith"],
+          );
+          const personId = personResult.rows[0]["id"];
+          await tx.query(
+            `INSERT INTO rejot_integration_tests_one.person_email (person_id, email) VALUES ($1, $2), ($1, $3)`,
+            [personId, "alice@example.com", "alice@work.com"],
+          );
+        });
+
+        const result = await pollForResult(
+          () => client.query(`SELECT * FROM rejot_integration_tests_one.destination_person_email`),
+          (res) => res.rows.length > 0,
+        );
+
+        if (result === null) {
+          await printSyncProcessOutput(syncProcess);
+        }
+
+        expect(result).not.toBeNull();
+        expect(result!.rows.length).toBeGreaterThan(0);
+      } finally {
+        // Ensure the sync process is stopped (gracefully)
+        syncProcess.kill("SIGINT");
+        const exitedGracefully = await waitForProcessExitOrTimeout(syncProcess, 2000);
+        if (!exitedGracefully) {
+          await printSyncProcessOutput(syncProcess);
+        }
+        await syncProcess.exited;
+      }
+    },
+    { timeout: 10000 },
+  );
+});

--- a/integration-tests/one/package.json
+++ b/integration-tests/one/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@rejot-dev/integration-tests-one",
+  "module": "index.ts",
+  "type": "module",
+  "private": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rejot-dev/rejot.git",
+    "directory": "integration-tests/one"
+  },
+  "devDependencies": {
+    "@types/bun": "latest"
+  },
+  "peerDependencies": {
+    "typescript": "^5"
+  },
+  "dependencies": {
+    "@rejot-dev/adapter-postgres": "workspace:*",
+    "@rejot-dev/cli": "workspace:*",
+    "@rejot-dev/contract": "workspace:*",
+    "@rejot-dev/contract-tools": "workspace:*",
+    "@rejot-dev/sync": "workspace:*",
+    "pg": "^8.11.3",
+    "zod": "^3.24.2"
+  }
+}

--- a/integration-tests/one/schemas/one-schema.ts
+++ b/integration-tests/one/schemas/one-schema.ts
@@ -1,0 +1,76 @@
+import { z } from "zod";
+
+import {
+  createPostgresConsumerSchemaConfig,
+  createPostgresPublicSchemaTransformations,
+  PostgresPublicSchemaConfigBuilder,
+} from "@rejot-dev/adapter-postgres";
+import { createConsumerSchema } from "@rejot-dev/contract/consumer-schema";
+import { createPublicSchema } from "@rejot-dev/contract/public-schema";
+
+const onePersonSchema = createPublicSchema("one-person", {
+  source: { dataStoreSlug: "main-connection" },
+  outputSchema: z.object({
+    id: z.number(),
+    firstName: z.string(),
+    lastName: z.string(),
+    emails: z.array(z.string()),
+  }),
+  config: new PostgresPublicSchemaConfigBuilder()
+    .addTransformation([
+      ...createPostgresPublicSchemaTransformations(
+        "insertOrUpdate",
+        "person",
+        `SELECT p.id, p.first_name as "firstName", p.last_name as "lastName", COALESCE(array_agg(e.email) FILTER (WHERE e.email IS NOT NULL), '{}') as emails
+         FROM rejot_integration_tests_one.person p
+         LEFT JOIN rejot_integration_tests_one.person_email e ON p.id = e.person_id
+         WHERE p.id = :id
+         GROUP BY p.id, p.first_name, p.last_name`,
+      ),
+      ...createPostgresPublicSchemaTransformations(
+        "insertOrUpdate",
+        "person_email",
+        `SELECT p.id, p.first_name as "firstName", p.last_name as "lastName", COALESCE(array_agg(e.email) FILTER (WHERE e.email IS NOT NULL), '{}') as emails
+         FROM rejot_integration_tests_one.person p
+         LEFT JOIN rejot_integration_tests_one.person_email e ON p.id = e.person_id
+         WHERE p.id = (SELECT person_id FROM rejot_integration_tests_one.person_email WHERE id = :id)
+         GROUP BY p.id, p.first_name, p.last_name`,
+      ),
+    ])
+    .build(),
+  version: {
+    major: 1,
+    minor: 0,
+  },
+});
+
+const testConsumerSchema = createConsumerSchema("consume-one-person", {
+  source: {
+    manifestSlug: "@rejot-dev/integration-tests-one",
+    publicSchema: {
+      name: "one-person",
+      majorVersion: 1,
+    },
+  },
+  config: createPostgresConsumerSchemaConfig(
+    "main-connection",
+    `
+      INSERT INTO rejot_integration_tests_one.destination_person_email 
+        (id, name, emails)
+      VALUES 
+        (:id, :firstName || ' ' || :lastName, array_to_string(:emails::text[], ','))
+      ON CONFLICT (id) DO UPDATE
+        SET name = :firstName || ' ' || :lastName,
+            emails = array_to_string(:emails::text[], ',')
+      ;
+    `,
+    {
+      deleteSql: "DELETE FROM rejot_integration_tests_one.destination_person_email WHERE id = :id",
+    },
+  ),
+});
+
+export default {
+  onePersonSchema,
+  testConsumerSchema,
+};

--- a/integration-tests/one/test-helpers.ts
+++ b/integration-tests/one/test-helpers.ts
@@ -1,0 +1,46 @@
+import type { Subprocess } from "bun";
+
+export async function pollForResult<T>(
+  fn: () => Promise<T>,
+  check: (result: T) => boolean,
+  intervalMs: number = 100,
+  timeoutMs: number = 3000,
+): Promise<T | null> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const result = await fn();
+    if (check(result)) {
+      return result;
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  return null;
+}
+
+// Helper to print sync process output
+export async function printSyncProcessOutput(syncProcess: Subprocess<"ignore", "pipe", "pipe">) {
+  if (syncProcess.stdout) {
+    const text = await Bun.readableStreamToText(syncProcess.stdout);
+    console.log("[syncProcess stdout]\n" + text);
+  }
+  if (syncProcess.stderr) {
+    const text = await Bun.readableStreamToText(syncProcess.stderr);
+    console.log("[syncProcess stderr]\n" + text);
+  }
+}
+
+// Helper to wait for process exit or timeout
+export async function waitForProcessExitOrTimeout(
+  proc: Subprocess<"ignore", "pipe", "pipe">,
+  timeoutMs: number = 2000,
+): Promise<boolean> {
+  let exited = false;
+  const race = Promise.race([
+    proc.exited.then(() => {
+      exited = true;
+    }),
+    new Promise((resolve) => setTimeout(resolve, timeoutMs)),
+  ]);
+  await race;
+  return exited;
+}

--- a/integration-tests/one/tsconfig.json
+++ b/integration-tests/one/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["dist"],
+  "references": [
+    {
+      "path": "../../packages/contract"
+    },
+    {
+      "path": "../../packages/contract-tools"
+    },
+    {
+      "path": "../../packages/sync"
+    },
+    {
+      "path": "../../packages/adapter-postgres"
+    },
+    {
+      "path": "../../apps/rejot-cli"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "packageManager": "npm@10.9.2",
   "workspaces": [
     "apps/*",
-    "packages/*"
+    "packages/*",
+    "integration-tests/*"
   ],
   "devDependencies": {
     "@eslint/js": "^9.20.0",

--- a/packages/adapter-postgres/src/adapter/create-schema.test.ts
+++ b/packages/adapter-postgres/src/adapter/create-schema.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+
+import { z } from "zod";
+
+import { PublicSchemaSchema } from "@rejot-dev/contract/manifest";
+import { createPublicSchema } from "@rejot-dev/contract/public-schema";
+
+import {
+  createPostgresPublicSchemaTransformations,
+  PostgresPublicSchemaConfigBuilder,
+} from "./index.ts";
+
+describe("PostgresPublicSchemaConfigBuilder", () => {
+  test("createPostgresPublicSchemaTransformations", () => {
+    const onePersonSchema = createPublicSchema("one-person", {
+      source: { dataStoreSlug: "main-connection" },
+      outputSchema: z.object({
+        id: z.number(),
+        firstName: z.string(),
+        lastName: z.string(),
+        emails: z.array(z.string()),
+      }),
+      config: new PostgresPublicSchemaConfigBuilder()
+        .addTransformation([
+          ...createPostgresPublicSchemaTransformations("insertOrUpdate", "person", `SELECT`),
+          ...createPostgresPublicSchemaTransformations("insertOrUpdate", "person_email", `SELECT`),
+        ])
+        .build(),
+      version: {
+        major: 1,
+        minor: 0,
+      },
+    });
+
+    const result = PublicSchemaSchema.safeParse(onePersonSchema);
+    expect(result.success).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+});

--- a/packages/adapter-postgres/src/adapter/pg-consumer-schema-transformation-adapter.ts
+++ b/packages/adapter-postgres/src/adapter/pg-consumer-schema-transformation-adapter.ts
@@ -145,7 +145,7 @@ export class PostgresConsumerSchemaTransformationAdapter
             : consumerSchema.config.sql;
 
         log.debug(
-          `Applying consumer schema ${consumerSchema.publicSchema.name}@${consumerSchema.publicSchema.majorVersion} ` +
+          `Applying consumer schema ${consumerSchema.name} ` +
             `(manifest: ${consumerSchema.sourceManifestSlug}) to operation from ` +
             `${operation.sourceManifestSlug}/${operation.sourcePublicSchema.name}@${operation.sourcePublicSchema.version.major} ` +
             `(${operation.type})`,
@@ -155,6 +155,8 @@ export class PostgresConsumerSchemaTransformationAdapter
 
         // Convert named placeholders to positional if necessary, and get the ordered values
         const { sql, values } = await convertNamedToPositionalPlaceholders(transformationSql, data);
+
+        log.trace(`Query: ${sql}`, { values });
 
         await client.query(sql, values);
         log.debug("Successfully applied transformation SQL.");

--- a/packages/adapter-postgres/src/sql-transformer/sql-transformer.test.ts
+++ b/packages/adapter-postgres/src/sql-transformer/sql-transformer.test.ts
@@ -216,6 +216,32 @@ describe("SQL Transformer", () => {
         "Not enough values provided for positional placeholders.",
       );
     });
+
+    test("should accept repeated positional placeholders as valid", () => {
+      expect(
+        positionalPlaceholdersAreSequential([
+          { value: "$1", line: 1, column: 10 },
+          { value: "$2", line: 1, column: 20 },
+          { value: "$1", line: 1, column: 30 },
+          { value: "$3", line: 1, column: 40 },
+        ]),
+      ).toBe(true);
+    });
+
+    test("convertNamedToPositionalPlaceholders should work with repeated positional placeholders", async () => {
+      const sql = `
+        INSERT INTO rejot_integration_tests_one.person_email (person_id, email)
+        VALUES ($1, $2), ($1, $3)
+      `;
+      // Should not throw, and should use the first three values
+      const result = await convertNamedToPositionalPlaceholders(sql, {
+        0: 42,
+        1: "a@example.com",
+        2: "b@example.com",
+      });
+      expect(result.sql).toContain("($1, $2), ($1, $3)");
+      expect(result.values.length).toBe(3);
+    });
   });
 
   describe("positionalPlaceholdersAreSequential", () => {

--- a/packages/contract/manifest/manifest.ts
+++ b/packages/contract/manifest/manifest.ts
@@ -53,8 +53,14 @@ export const PostgresConsumerSchemaConfigSchema = z.object({
 
 export const PostgresDataStoreSchema = z.object({
   connectionType: z.literal("postgres").describe("Postgres connection type."),
-  slotName: z.string().describe("Name of the replication slot."),
-  publicationName: z.string().describe("Name of the publication."),
+  slotName: z
+    .string()
+    .describe("Name of the replication slot.")
+    .regex(/^[a-z0-9_]+$/),
+  publicationName: z
+    .string()
+    .describe("Name of the publication.")
+    .regex(/^[a-z0-9_]+$/),
   tables: z.array(z.string()).describe("Tables to replicate.").optional(),
   allTables: z.boolean().describe("When true, all tables are replicated.").optional(),
 });

--- a/packages/contract/schema.json
+++ b/packages/contract/schema.json
@@ -103,10 +103,12 @@
                   },
                   "slotName": {
                     "type": "string",
+                    "pattern": "^[a-z0-9_]+$",
                     "description": "Name of the replication slot."
                   },
                   "publicationName": {
                     "type": "string",
+                    "pattern": "^[a-z0-9_]+$",
                     "description": "Name of the publication."
                   },
                   "tables": {

--- a/packages/sync/src/http-controller/bun-http-controller.ts
+++ b/packages/sync/src/http-controller/bun-http-controller.ts
@@ -23,7 +23,13 @@ export class BunHttpController extends HttpController {
     if (!this.#server) {
       throw new Error("Server is not listening");
     }
-    return this.#server.port;
+    const assignedPort = this.#server.port;
+
+    if (!assignedPort) {
+      throw new Error("Server is not listening");
+    }
+
+    return assignedPort;
   }
 
   /**

--- a/scripts/check-dockerfile-packages.ts
+++ b/scripts/check-dockerfile-packages.ts
@@ -2,6 +2,7 @@
 
 import { readFileSync } from "fs";
 import { join } from "path";
+
 import { getAllWorkspacePackages } from "./workspace-utils";
 
 function getDockerfilePackages(dockerfilePath: string): string[] {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     { "path": "apps/mcp" },
     { "path": "apps/rejot-cli" },
     { "path": "apps/controller-spa" },
-    { "path": "apps/controller" }
+    { "path": "apps/controller" },
+    { "path": "integration-tests/one" }
   ]
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Added a new integration test suite called "one" to test end-to-end data sync between Postgres tables using the rejot CLI and schema tools.

- **New Features**
  - Created `integration-tests/one` with setup scripts, schema definitions, and a full sync test.
  - Updated CI to run the new integration test.
  - Improved positional placeholder handling in SQL transformer for repeated placeholders.
  - Added stricter validation for Postgres slot and publication names.

<!-- End of auto-generated description by mrge. -->

