### PR TITLE
Docs: Move typescript code examples to their own file, so they get typechecked by CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,11 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: build static site types
+        working-directory: apps/static-site
+        # This generates the .astro/types.d.ts file needed for the build later on
+        run: bunx astro sync
+
       - name: Cache dependencies
         uses: actions/cache/save@v4
         with:
@@ -31,6 +36,7 @@ jobs:
             packages/*/dist
             apps/*/dist
             **/tsconfig.tsbuildinfo
+            **/.astro
           key: ${{ runner.os }}-modules-${{ hashFiles('**/bun.lock') }}
 
       - name: Define packages
@@ -57,6 +63,7 @@ jobs:
             packages/*/dist
             apps/*/dist
             **/tsconfig.tsbuildinfo
+            **/.astro
           key: ${{ runner.os }}-modules-${{ hashFiles('**/bun.lock') }}
 
       - name: Check formatting
@@ -82,6 +89,7 @@ jobs:
             packages/*/dist
             apps/*/dist
             **/tsconfig.tsbuildinfo
+            **/.astro
           key: ${{ runner.os }}-modules-${{ hashFiles('**/bun.lock') }}
 
       - name: Run linter
@@ -107,6 +115,7 @@ jobs:
             packages/*/dist
             apps/*/dist
             **/tsconfig.tsbuildinfo
+            **/.astro
           key: ${{ runner.os }}-modules-${{ hashFiles('**/bun.lock') }}
 
       - name: Type check
@@ -137,6 +146,7 @@ jobs:
             packages/*/dist
             apps/*/dist
             **/tsconfig.tsbuildinfo
+            **/.astro
           key: ${{ runner.os }}-modules-${{ hashFiles('**/bun.lock') }}
 
       - name: Run tests for ${{ matrix.package }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,7 @@ coverage
 # Ignore generated files:
 **/drizzle/**
 packages/contract/schema.json
+**/.astro
 
 # Ignored symbolic links:
 apps/static-site/public/content/docs/rejot-architecture.svg

--- a/apps/static-site/package.json
+++ b/apps/static-site/package.json
@@ -38,6 +38,8 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20241218.0",
     "@mdx-js/mdx": "^3.1.0",
+    "@rejot-dev/contract": "workspace:*",
+    "@rejot-dev/adapter-postgres": "workspace:*",
     "@tailwindcss/typography": "^0.5.15",
     "@types/cheerio": "^0.22.35",
     "@types/json-pointer": "^1.0.34",

--- a/apps/static-site/src/content/docs/0_start/3_quickstart.mdx
+++ b/apps/static-site/src/content/docs/0_start/3_quickstart.mdx
@@ -2,7 +2,9 @@
 title: "Quickstart"
 ---
 
+import { Code } from "astro:components";
 import Notice from "@/components/Notice.astro";
+import rawSchemaText from "./schema.ts?raw";
 
 This guide helps you quickly set up data synchronization between PostgreSQL databases using ReJot
 manifests. For demonstration purposes we'll use one postgres database for both publishing and
@@ -73,59 +75,14 @@ Public and Consumer Schemas can be created through Typescript code, create a `sc
 containing your schemas. See our full [guide on defining schemas](/docs/guides/defining-schemas) for
 more detailed description of the schema definition process.
 
-```typescript
-// schemas.ts
-import { z } from "zod";
-
-import {
-  createPostgresPublicSchemaTransformation,
-  createPostgresConsumerSchemaTransformation,
-} from "@rejot-dev/adapter-postgres";
-import { createConsumerSchema } from "@rejot-dev/contract/consumer-schema";
-import { createPublicSchema } from "@rejot-dev/contract/public-schema";
-
-// Public schema definition for api_key table
-const apiKeyPublicSchema = createPublicSchema("my-public-schema", {
-  source: { dataStoreSlug: "my-db", tables: ["api_key"] },
-  outputSchema: z.object({
-    id: z.string(),
-    api_key: z.string(),
-  }),
-  transformations: [
-    createPostgresPublicSchemaTransformation(
-      "api_key",
-      `SELECT id, key AS "api_key" FROM api_key WHERE id = $1`,
-    ),
-  ],
-  version: {
-    major: 1,
-    minor: 0,
-  },
-});
-
-// Consumer schema that writes to target_table
-const apiKeyConsumerSchema = createConsumerSchema("my-consumer-schema", {
-  source: {
-    manifestSlug: "my-sync-project",
-    publicSchema: {
-      name: "my-public-schema",
-      majorVersion: 1,
-    },
-  },
-  destinationDataStoreSlug: "my-db",
-  transformations: [
-    createPostgresConsumerSchemaTransformation(
-      `INSERT INTO target_table (id, api_key) VALUES (:id, :api_key)
-       ON CONFLICT (id) DO UPDATE SET api_key = :api_key`,
-    ),
-  ],
-});
-
-export default {
-  apiKeyPublicSchema,
-  apiKeyConsumerSchema,
-};
-```
+<Code
+  code={rawSchemaText}
+  lang="ts"
+  themes={{
+    light: "github-light",
+    dark: "github-dark",
+  }}
+/>
 
 ### Collect Schemas to Manifest
 

--- a/apps/static-site/src/content/docs/0_start/schema.ts
+++ b/apps/static-site/src/content/docs/0_start/schema.ts
@@ -1,0 +1,51 @@
+// schemas.ts
+import { z } from "zod";
+
+import {
+  createPostgresConsumerSchemaTransformation,
+  createPostgresPublicSchemaTransformation,
+} from "@rejot-dev/adapter-postgres";
+import { createConsumerSchema } from "@rejot-dev/contract/consumer-schema";
+import { createPublicSchema } from "@rejot-dev/contract/public-schema";
+
+// Public schema definition for api_key table
+const apiKeyPublicSchema = createPublicSchema("my-public-schema", {
+  source: { dataStoreSlug: "my-db", tables: ["api_key"] },
+  outputSchema: z.object({
+    id: z.string(),
+    api_key: z.string(),
+  }),
+  transformations: [
+    createPostgresPublicSchemaTransformation(
+      "api_key",
+      `SELECT id, key AS "api_key" FROM api_key WHERE id = $1`,
+    ),
+  ],
+  version: {
+    major: 1,
+    minor: 0,
+  },
+});
+
+// Consumer schema that writes to target_table
+const apiKeyConsumerSchema = createConsumerSchema("my-consumer-schema", {
+  source: {
+    manifestSlug: "my-sync-project",
+    publicSchema: {
+      name: "my-public-schema",
+      majorVersion: 1,
+    },
+  },
+  destinationDataStoreSlug: "my-db",
+  transformations: [
+    createPostgresConsumerSchemaTransformation(
+      `INSERT INTO target_table (id, api_key) VALUES (:id, :api_key)
+       ON CONFLICT (id) DO UPDATE SET api_key = :api_key`,
+    ),
+  ],
+});
+
+export default {
+  apiKeyPublicSchema,
+  apiKeyConsumerSchema,
+};

--- a/apps/static-site/src/content/docs/1_guides/1_defining-schemas.mdx
+++ b/apps/static-site/src/content/docs/1_guides/1_defining-schemas.mdx
@@ -4,6 +4,7 @@ title: "Defining Schemas"
 
 import { Code } from "astro:components";
 import Notice from "@/components/Notice.astro";
+import rawSchemaText from "./schema.ts?raw";
 
 ReJot allows you to define Public and Consumer Schemas using TypeScript code, which offers several
 benefits:
@@ -24,46 +25,14 @@ npm install --save @rejot-dev/contract @rejot-dev/adapter-postgres
 
 Create a new file called `schemas.ts` that will contain your public and consumer schemas:
 
-```typescript
-import { z } from "zod";
-
-import {
-  createPostgresPublicSchemaTransformation,
-  createPostgresConsumerSchemaConfig,
-} from "@rejot-dev/adapter-postgres";
-import { createConsumerSchema } from "@rejot-dev/contract/consumer-schema";
-import { createPublicSchema } from "@rejot-dev/contract/public-schema";
-
-const myPublicSchema = createPublicSchema("my-public-schema", {
-  source: { dataStoreSlug: "my-source-datastore", tables: ["my_table"] },
-  outputSchema: z.object({
-    id: z.string(),
-    name: z.string(),
-  }),
-  transformations: [], // See next step
-  version: {
-    major: 1,
-    minor: 0,
-  },
-});
-
-const myConsumerSchema = createConsumerSchema({
-  source: {
-    manifestSlug: "my-manifest",
-    publicSchema: {
-      name: "my-public-schema",
-      majorVersion: 1,
-    },
-  },
-  destinationDataStoreSlug: "my-destination-datastore",
-  transformations: [], // See next step
-});
-
-export default {
-  myPublicSchema,
-  myConsumerSchema,
-};
-```
+<Code
+  code={rawSchemaText}
+  lang="ts"
+  themes={{
+    light: "github-light",
+    dark: "github-dark",
+  }}
+/>
 
 ### Transformations
 

--- a/apps/static-site/src/content/docs/1_guides/1_defining-schemas.mdx
+++ b/apps/static-site/src/content/docs/1_guides/1_defining-schemas.mdx
@@ -53,12 +53,14 @@ These transformations:
 Here's an example of a public schema transformation:
 
 ```typescript
-transformations: [
-  createPostgresPublicSchemaTransformation(
-    "my_table",
-    `SELECT id, name FROM my_table WHERE id = $1`,
-  ),
-];
+import { createPostgresPublicSchemaTransformations } from "@rejot-dev/adapter-postgres";
+
+// ... in myPublicSchema
+transformations: createPostgresPublicSchemaTransformations(
+      "insertOrUpdate",
+      "my_table",
+      `SELECT id, name FROM my_table WHERE id = $1`,
+    ),
 ```
 
 #### Multi-table transformations
@@ -68,32 +70,37 @@ results ReJot should listen to updates to all of these tables. As a data produce
 define schema transformations for each table.
 
 ```typescript
+import { createPostgresPublicSchemaTransformations } from "@rejot-dev/adapter-postgres";
+
+// ... in myPublicSchema
 transformations: [
-    createPostgresPublicSchemaTransformation(
-      "accounts",
-      `SELECT
-          accounts.id,
-          accounts.name,
-          addresses.country
-        FROM
-          accounts
-          JOIN addresses ON accounts.id = addresses.account_id
-        WHERE
-          accounts.id = $1`,
-    ),
-    createPostgresPublicSchemaTransformation(
-      "addresses",
-      `SELECT
-          accounts.id,
-          accounts.name,
-          addresses.country
-        FROM
-          accounts
-          JOIN addresses ON accounts.id = addresses.account_id
-        WHERE
-          addresses.id = $1`,
-    ),
-  ],
+      ...createPostgresPublicSchemaTransformations(
+        "insertOrUpdate",
+        "accounts",
+        `SELECT
+            accounts.id,
+            accounts.name,
+            addresses.country
+          FROM
+            accounts
+            JOIN addresses ON accounts.id = addresses.account_id
+          WHERE
+            accounts.id = $1`,
+      ),
+      ...createPostgresPublicSchemaTransformations(
+        "insertOrUpdate",
+        "addresses",
+        `SELECT
+            accounts.id,
+            accounts.name,
+            addresses.country
+          FROM
+            accounts
+            JOIN addresses ON accounts.id = addresses.account_id
+          WHERE
+            addresses.id = $1`,
+      ),
+    ],
 ```
 
 <Notice type="WARNING">
@@ -114,11 +121,7 @@ destination data store. These transformations:
 Here's an example of a consumer schema transformation:
 
 ```typescript
-transformations: [
-  createPostgresConsumerSchemaConfig(
-    "INSERT INTO destination_table (id, name) VALUES (:id, :name) ON CONFLICT (id) DO UPDATE SET name = :name",
-  ),
-];
+sql: "INSERT INTO destination_table (id, name) VALUES (:id, :name) ON CONFLICT (id) DO UPDATE SET name = :name";
 ```
 
 ## Materializing Schemas

--- a/apps/static-site/src/content/docs/1_guides/schema.ts
+++ b/apps/static-site/src/content/docs/1_guides/schema.ts
@@ -1,0 +1,35 @@
+// schema.ts
+import { z } from "zod";
+
+import { createConsumerSchema } from "@rejot-dev/contract/consumer-schema";
+import { createPublicSchema } from "@rejot-dev/contract/public-schema";
+
+const myPublicSchema = createPublicSchema("my-public-schema", {
+  source: { dataStoreSlug: "my-source-datastore", tables: ["my_table"] },
+  outputSchema: z.object({
+    id: z.string(),
+    name: z.string(),
+  }),
+  transformations: [], // See next step
+  version: {
+    major: 1,
+    minor: 0,
+  },
+});
+
+const myConsumerSchema = createConsumerSchema({
+  source: {
+    manifestSlug: "my-manifest",
+    publicSchema: {
+      name: "my-public-schema",
+      majorVersion: 1,
+    },
+  },
+  destinationDataStoreSlug: "my-destination-datastore",
+  transformations: [], // See next step
+});
+
+export default {
+  myPublicSchema,
+  myConsumerSchema,
+};

--- a/apps/static-site/src/content/docs/1_guides/schema.ts
+++ b/apps/static-site/src/content/docs/1_guides/schema.ts
@@ -5,19 +5,22 @@ import { createConsumerSchema } from "@rejot-dev/contract/consumer-schema";
 import { createPublicSchema } from "@rejot-dev/contract/public-schema";
 
 const myPublicSchema = createPublicSchema("my-public-schema", {
-  source: { dataStoreSlug: "my-source-datastore", tables: ["my_table"] },
+  source: { dataStoreSlug: "my-source-datastore" },
   outputSchema: z.object({
     id: z.string(),
     name: z.string(),
   }),
-  transformations: [], // See next step
+  config: {
+    publicSchemaType: "postgres",
+    transformations: [], // See next step
+  },
   version: {
     major: 1,
     minor: 0,
   },
 });
 
-const myConsumerSchema = createConsumerSchema({
+const myConsumerSchema = createConsumerSchema("my-consumer-schema", {
   source: {
     manifestSlug: "my-manifest",
     publicSchema: {
@@ -25,8 +28,11 @@ const myConsumerSchema = createConsumerSchema({
       majorVersion: 1,
     },
   },
-  destinationDataStoreSlug: "my-destination-datastore",
-  transformations: [], // See next step
+  config: {
+    consumerSchemaType: "postgres",
+    destinationDataStoreSlug: "my-destination-datastore",
+    sql: "", // See next step
+  },
 });
 
 export default {

--- a/apps/static-site/src/layouts/Base.astro
+++ b/apps/static-site/src/layouts/Base.astro
@@ -2,7 +2,6 @@
 import BaseHead from "../components/BaseHead.astro";
 import Header from "../components/header/Header.astro";
 import Footer from "../components/Footer.astro";
-import SearchModal from "../components/SearchModal.astro";
 
 type Props = {
   title: string;

--- a/apps/static-site/tsconfig.json
+++ b/apps/static-site/tsconfig.json
@@ -10,6 +10,8 @@
     ],
     "strictNullChecks": true,
     "baseUrl": ".",
+    "noEmit": true,
+    "outDir": "./dist",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/apps/static-site/tsconfig.json
+++ b/apps/static-site/tsconfig.json
@@ -13,5 +13,13 @@
     "paths": {
       "@/*": ["./src/*"]
     }
-  }
+  },
+  "references": [
+    {
+      "path": "../../packages/contract"
+    },
+    {
+      "path": "../../packages/adapter-postgres"
+    }
+  ]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -190,6 +190,8 @@
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20241218.0",
         "@mdx-js/mdx": "^3.1.0",
+        "@rejot-dev/adapter-postgres": "workspace:*",
+        "@rejot-dev/contract": "workspace:*",
         "@tailwindcss/typography": "^0.5.15",
         "@types/cheerio": "^0.22.35",
         "@types/json-pointer": "^1.0.34",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,7 +23,7 @@ const _unicornFixableRules = Object.fromEntries(
 
 export default tseslint.config(
   {
-    ignores: ["**/node_modules/**", "**/dist/**", "apps/docs/.astro/**"],
+    ignores: ["**/node_modules/**", "**/dist/**", "apps/static-site/.astro/**"],
   },
   eslint.configs.recommended,
   tseslint.configs.recommended,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "apps/rejot-cli" },
     { "path": "apps/controller-spa" },
     { "path": "apps/controller" },
+    { "path": "apps/static-site" },
     { "path": "integration-tests/one" }
   ]
 }


### PR DESCRIPTION
Draft as the type check should fail, as there are type errors in schema.ts in the documentation 