### PR TITLE
Docs: Fix mentions of rejot instead of rejot-cli in the docs

### DIFF
--- a/apps/rejot-cli/cli-schema.json
+++ b/apps/rejot-cli/cli-schema.json
@@ -87,8 +87,8 @@
       "id": "manifest:init",
       "description": "Initialize a new manifest file",
       "examples": [
-        "<%= config.bin %> manifest init",
-        "<%= config.bin %> manifest init --manifest ./custom-manifest.json"
+        "<%= config.bin %> <%= command.id %>",
+        "<%= config.bin %> <%= command.id %> --manifest ./custom-manifest.json"
       ],
       "flags": {
         "manifest": {
@@ -110,8 +110,8 @@
       "id": "manifest:connection:add",
       "description": "Add a connection to the manifest file",
       "examples": [
-        "<%= config.bin %> manifest connection add --slug my-db --connection-string \"postgresql://user:pass@host:5432/db\"",
-        "<%= config.bin %> manifest connection add --slug my-db --type postgres --host localhost --port 5432 --user postgres --password secret --database mydb"
+        "<%= config.bin %> <%= command.id %> --slug my-db --connection-string \"postgresql://user:pass@host:5432/db\"",
+        "<%= config.bin %> <%= command.id %> --slug my-db --type postgres --host localhost --port 5432 --user postgres --password secret --database mydb"
       ],
       "flags": {
         "manifest": {
@@ -178,7 +178,7 @@
       "id": "manifest:connection:remove",
       "description": "Remove a connection from the manifest file",
       "examples": [
-        "<%= config.bin %> manifest connection remove my-db"
+        "<%= config.bin %> <%= command.id %> my-db"
       ],
       "args": {
         "slug": {
@@ -201,7 +201,7 @@
       "id": "manifest:connection:list",
       "description": "List all connections in the manifest file",
       "examples": [
-        "<%= config.bin %> manifest connection list"
+        "<%= config.bin %> <%= command.id %>"
       ],
       "flags": {
         "manifest": {
@@ -217,8 +217,8 @@
       "id": "manifest:connection:update",
       "description": "Update an existing connection in the manifest file",
       "examples": [
-        "<%= config.bin %> manifest connection update my-db --connection-string \"postgresql://user:pass@host:5432/db\"",
-        "<%= config.bin %> manifest connection update my-db --type postgres --host localhost --port 5432 --user postgres --password secret --database mydb"
+        "<%= config.bin %> <%= command.id %> my-db --connection-string \"postgresql://user:pass@host:5432/db\"",
+        "<%= config.bin %> <%= command.id %> my-db --type postgres --host localhost --port 5432 --user postgres --password secret --database mydb"
       ],
       "args": {
         "slug": {
@@ -286,7 +286,7 @@
       "id": "manifest:datastore:add",
       "description": "Add a data store to the manifest file",
       "examples": [
-        "<%= config.bin %> manifest datastore add --connection my-db --publication my-pub"
+        "<%= config.bin %> <%= command.id %> --connection my-db --publication my-pub"
       ],
       "flags": {
         "manifest": {
@@ -320,7 +320,7 @@
       "id": "manifest:datastore:remove",
       "description": "Remove a data store from the manifest file",
       "examples": [
-        "<%= config.bin %> manifest datastore remove my-db"
+        "<%= config.bin %> <%= command.id %> my-db"
       ],
       "args": {
         "connectionSlug": {
@@ -361,7 +361,7 @@
       "id": "manifest:datastore:list",
       "description": "List all data stores in the manifest file",
       "examples": [
-        "<%= config.bin %> manifest datastore list"
+        "<%= config.bin %> <%= command.id %>"
       ],
       "flags": {
         "manifest": {
@@ -395,7 +395,7 @@
       "id": "manifest:eventstore:add",
       "description": "Add an event store to the manifest file",
       "examples": [
-        "<%= config.bin %> manifest eventstore add --connection my-db"
+        "<%= config.bin %> <%= command.id %> --connection my-db"
       ],
       "flags": {
         "manifest": {
@@ -417,7 +417,7 @@
       "id": "manifest:eventstore:remove",
       "description": "Remove an event store from the manifest file",
       "examples": [
-        "<%= config.bin %> manifest:eventstore:remove my-db"
+        "<%= config.bin %> <%= command.id %> my-db"
       ],
       "args": {
         "slug": {
@@ -440,7 +440,7 @@
       "id": "manifest:eventstore:list",
       "description": "List event stores in the manifest file",
       "examples": [
-        "<%= config.bin %> manifest:eventstore:list"
+        "<%= config.bin %> <%= command.id %>"
       ],
       "flags": {
         "manifest": {
@@ -456,8 +456,8 @@
       "id": "manifest:sync",
       "description": "Start syncing based on one or more manifest files.\n\n    Opens replication slots in the source data stores, transforms writes using public schemas,\n    and stores the events in the configured event store.",
       "examples": [
-        "<%= config.bin %> manifest sync ./rejot-manifest.json",
-        "<%= config.bin %> manifest sync ./manifest1.json ./manifest2.json"
+        "<%= config.bin %> <%= command.id %> ./rejot-manifest.json",
+        "<%= config.bin %> <%= command.id %> ./manifest1.json ./manifest2.json"
       ],
       "args": {
         "manifest": {
@@ -510,8 +510,8 @@
       "id": "workspace:info",
       "description": "Display information about the current workspace configuration and diagnostics",
       "examples": [
-        "<%= config.bin %> workspace info",
-        "<%= config.bin %> workspace info --filename custom-manifest.json"
+        "<%= config.bin %> <%= command.id %>",
+        "<%= config.bin %> <%= command.id %> --filename custom-manifest.json"
       ],
       "flags": {
         "filename": {
@@ -526,8 +526,8 @@
       "id": "workspace:init",
       "description": "Initialize a new ReJot workspace",
       "examples": [
-        "<%= config.bin %> workspace init --slug @myorg/",
-        "<%= config.bin %> workspace init --slug @myorg/ --filename custom-manifest.json"
+        "<%= config.bin %> <%= command.id %> --slug @myorg/",
+        "<%= config.bin %> <%= command.id %> --slug @myorg/ --filename custom-manifest.json"
       ],
       "flags": {
         "filename": {

--- a/apps/rejot-cli/src/commands/manifest-connection/manifest-connection-add.command.ts
+++ b/apps/rejot-cli/src/commands/manifest-connection/manifest-connection-add.command.ts
@@ -12,9 +12,9 @@ export class ManifestConnectionAddCommand extends Command {
 
   static override examples = [
     // Connection string examples
-    '<%= config.bin %> manifest connection add --slug my-db --connection-string "postgresql://user:pass@host:5432/db"',
+    '<%= config.bin %> <%= command.id %> --slug my-db --connection-string "postgresql://user:pass@host:5432/db"',
     // Individual parameter examples
-    "<%= config.bin %> manifest connection add --slug my-db --type postgres --host localhost --port 5432 --user postgres --password secret --database mydb",
+    "<%= config.bin %> <%= command.id %> --slug my-db --type postgres --host localhost --port 5432 --user postgres --password secret --database mydb",
   ];
 
   static override flags = {

--- a/apps/rejot-cli/src/commands/manifest-connection/manifest-connection-list.command.ts
+++ b/apps/rejot-cli/src/commands/manifest-connection/manifest-connection-list.command.ts
@@ -8,7 +8,7 @@ export class ManifestConnectionListCommand extends Command {
   static override id = "manifest connection list";
   static override description = "List all connections in the manifest file";
 
-  static override examples = ["<%= config.bin %> manifest connection list"];
+  static override examples = ["<%= config.bin %> <%= command.id %>"];
 
   static override flags = {
     manifest: Flags.string({

--- a/apps/rejot-cli/src/commands/manifest-connection/manifest-connection-remove.command.ts
+++ b/apps/rejot-cli/src/commands/manifest-connection/manifest-connection-remove.command.ts
@@ -8,7 +8,7 @@ export class ManifestConnectionRemoveCommand extends Command {
   static override id = "manifest connection remove";
   static override description = "Remove a connection from the manifest file";
 
-  static override examples = ["<%= config.bin %> manifest connection remove my-db"];
+  static override examples = ["<%= config.bin %> <%= command.id %> my-db"];
 
   static override flags = {
     manifest: Flags.string({

--- a/apps/rejot-cli/src/commands/manifest-connection/manifest-connection-update.command.ts
+++ b/apps/rejot-cli/src/commands/manifest-connection/manifest-connection-update.command.ts
@@ -12,9 +12,9 @@ export class ManifestConnectionUpdateCommand extends Command {
 
   static override examples = [
     // Connection string examples
-    '<%= config.bin %> manifest connection update my-db --connection-string "postgresql://user:pass@host:5432/db"',
+    '<%= config.bin %> <%= command.id %> my-db --connection-string "postgresql://user:pass@host:5432/db"',
     // Individual parameter examples
-    "<%= config.bin %> manifest connection update my-db --type postgres --host localhost --port 5432 --user postgres --password secret --database mydb",
+    "<%= config.bin %> <%= command.id %> my-db --type postgres --host localhost --port 5432 --user postgres --password secret --database mydb",
   ];
 
   static override flags = {

--- a/apps/rejot-cli/src/commands/manifest-datastore/manifest-datastore-add.command.ts
+++ b/apps/rejot-cli/src/commands/manifest-datastore/manifest-datastore-add.command.ts
@@ -11,11 +11,11 @@ import {
 } from "./manifest-datastore-config.ts";
 
 export class ManifestDataStoreAddCommand extends Command {
-  static override id = "manifest:datastore:add";
+  static override id = "manifest datastore add";
   static override description = "Add a data store to the manifest file";
 
   static override examples = [
-    "<%= config.bin %> manifest datastore add --connection my-db --publication my-pub",
+    "<%= config.bin %> <%= command.id %> --connection my-db --publication my-pub",
   ];
 
   static override flags = manifestFlags;

--- a/apps/rejot-cli/src/commands/manifest-datastore/manifest-datastore-list.command.ts
+++ b/apps/rejot-cli/src/commands/manifest-datastore/manifest-datastore-list.command.ts
@@ -7,10 +7,10 @@ import { Command } from "@oclif/core";
 import { manifestFlags } from "./manifest-datastore-config.ts";
 
 export class ManifestDataStoreListCommand extends Command {
-  static override id = "manifest:datastore:list";
+  static override id = "manifest datastore list";
   static override description = "List all data stores in the manifest file";
 
-  static override examples = ["<%= config.bin %> manifest datastore list"];
+  static override examples = ["<%= config.bin %> <%= command.id %>"];
 
   static override flags = manifestFlags;
 

--- a/apps/rejot-cli/src/commands/manifest-datastore/manifest-datastore-remove.command.ts
+++ b/apps/rejot-cli/src/commands/manifest-datastore/manifest-datastore-remove.command.ts
@@ -10,10 +10,10 @@ import { Args, Command } from "@oclif/core";
 import { manifestFlags, validateDataStoreExists } from "./manifest-datastore-config.ts";
 
 export class ManifestDataStoreRemoveCommand extends Command {
-  static override id = "manifest:datastore:remove";
+  static override id = "manifest datastore remove";
   static override description = "Remove a data store from the manifest file";
 
-  static override examples = ["<%= config.bin %> manifest datastore remove my-db"];
+  static override examples = ["<%= config.bin %> <%= command.id %> my-db"];
 
   static override flags = manifestFlags;
 

--- a/apps/rejot-cli/src/commands/manifest-eventstore/manifest-eventstore-add.command.ts
+++ b/apps/rejot-cli/src/commands/manifest-eventstore/manifest-eventstore-add.command.ts
@@ -5,10 +5,10 @@ import { readManifestOrGetEmpty, writeManifest } from "@rejot-dev/contract-tools
 import { Command, Flags } from "@oclif/core";
 
 export class ManifestEventStoreAddCommand extends Command {
-  static override id = "manifest:eventstore:add";
+  static override id = "manifest eventstore add";
   static override description = "Add an event store to the manifest file";
 
-  static override examples = ["<%= config.bin %> manifest eventstore add --connection my-db"];
+  static override examples = ["<%= config.bin %> <%= command.id %> --connection my-db"];
 
   static override flags = {
     manifest: Flags.string({

--- a/apps/rejot-cli/src/commands/manifest-eventstore/manifest-eventstore-list.command.ts
+++ b/apps/rejot-cli/src/commands/manifest-eventstore/manifest-eventstore-list.command.ts
@@ -5,10 +5,10 @@ import { readManifestOrGetEmpty } from "@rejot-dev/contract-tools/manifest";
 import { Command, Flags } from "@oclif/core";
 
 export class ManifestEventStoreListCommand extends Command {
-  static override id = "manifest:eventstore:list";
+  static override id = "manifest eventstore list";
   static override description = "List event stores in the manifest file";
 
-  static override examples = ["<%= config.bin %> manifest:eventstore:list"];
+  static override examples = ["<%= config.bin %> <%= command.id %>"];
 
   static override flags = {
     manifest: Flags.string({

--- a/apps/rejot-cli/src/commands/manifest-eventstore/manifest-eventstore-remove.command.ts
+++ b/apps/rejot-cli/src/commands/manifest-eventstore/manifest-eventstore-remove.command.ts
@@ -5,10 +5,10 @@ import { readManifestOrGetEmpty, writeManifest } from "@rejot-dev/contract-tools
 import { Args, Command, Flags } from "@oclif/core";
 
 export class ManifestEventStoreRemoveCommand extends Command {
-  static override id = "manifest:eventstore:remove";
+  static override id = "manifest eventstore remove";
   static override description = "Remove an event store from the manifest file";
 
-  static override examples = ["<%= config.bin %> manifest:eventstore:remove my-db"];
+  static override examples = ["<%= config.bin %> <%= command.id %> my-db"];
 
   static override flags = {
     manifest: Flags.string({

--- a/apps/rejot-cli/src/commands/manifest/manifest-init.command.ts
+++ b/apps/rejot-cli/src/commands/manifest/manifest-init.command.ts
@@ -9,8 +9,8 @@ export class ManifestInitCommand extends Command {
   static override description = "Initialize a new manifest file";
 
   static override examples = [
-    "<%= config.bin %> manifest init",
-    "<%= config.bin %> manifest init --manifest ./custom-manifest.json",
+    "<%= config.bin %> <%= command.id %>",
+    "<%= config.bin %> <%= command.id %> --manifest ./custom-manifest.json",
   ];
 
   static override flags = {
@@ -33,9 +33,15 @@ export class ManifestInitCommand extends Command {
       await initManifest(manifestPath, slug);
       this.log(`Created new manifest file at ${manifestPath}`);
       this.log("\nNext steps:");
-      this.log("1. Add a connection:    rejot-cli manifest connection add --slug my-db ...");
-      this.log("2. Add a data store:    rejot-cli manifest datastore add --connection my-db ...");
-      this.log("3. Add an event store:  rejot-cli manifest eventstore add --connection my-target");
+      this.log(
+        `1. Add a connection:    ${this.config.bin} manifest connection add --slug my-db ...`,
+      );
+      this.log(
+        `2. Add a data store:    ${this.config.bin} manifest datastore add --connection my-db ...`,
+      );
+      this.log(
+        `3. Add an event store:  ${this.config.bin} manifest eventstore add --connection my-target`,
+      );
     } catch (error) {
       if (error instanceof Error) {
         if ("code" in error && error.code === "EEXIST") {

--- a/apps/rejot-cli/src/commands/manifest/manifest-sync.command.ts
+++ b/apps/rejot-cli/src/commands/manifest/manifest-sync.command.ts
@@ -29,15 +29,15 @@ import { Args, Command, Flags } from "@oclif/core";
 const log = getLogger(import.meta.url);
 
 export class ManifestSyncCommand extends Command {
-  static override id = "manifest:sync";
+  static override id = "manifest sync";
 
   static override description = `Start syncing based on one or more manifest files.\n
     Opens replication slots in the source data stores, transforms writes using public schemas,
     and stores the events in the configured event store.`;
 
   static override examples = [
-    "<%= config.bin %> manifest sync ./rejot-manifest.json",
-    "<%= config.bin %> manifest sync ./manifest1.json ./manifest2.json",
+    "<%= config.bin %> <%= command.id %> ./rejot-manifest.json",
+    "<%= config.bin %> <%= command.id %> ./manifest1.json ./manifest2.json",
   ];
 
   static override flags = {

--- a/apps/rejot-cli/src/commands/workspace/workspace-info.command.ts
+++ b/apps/rejot-cli/src/commands/workspace/workspace-info.command.ts
@@ -6,13 +6,13 @@ import { ManifestWorkspaceResolver } from "@rejot-dev/contract-tools/manifest/ma
 import { Command, Flags } from "@oclif/core";
 
 export class WorkspaceInfoCommand extends Command {
-  static override id = "workspace:info";
+  static override id = "workspace info";
   static override description =
     "Display information about the current workspace configuration and diagnostics";
 
   static override examples = [
-    "<%= config.bin %> workspace info",
-    "<%= config.bin %> workspace info --filename custom-manifest.json",
+    "<%= config.bin %> <%= command.id %>",
+    "<%= config.bin %> <%= command.id %> --filename custom-manifest.json",
   ];
 
   static override flags = {

--- a/apps/rejot-cli/src/commands/workspace/workspace-init.command.ts
+++ b/apps/rejot-cli/src/commands/workspace/workspace-init.command.ts
@@ -5,12 +5,12 @@ import { initManifest } from "@rejot-dev/contract-tools/manifest";
 import { Command, Flags } from "@oclif/core";
 
 export class WorkspaceInitCommand extends Command {
-  static override id = "workspace:init";
+  static override id = "workspace init";
   static override description = "Initialize a new ReJot workspace";
 
   static override examples = [
-    "<%= config.bin %> workspace init --slug @myorg/",
-    "<%= config.bin %> workspace init --slug @myorg/ --filename custom-manifest.json",
+    "<%= config.bin %> <%= command.id %> --slug @myorg/",
+    "<%= config.bin %> <%= command.id %> --slug @myorg/ --filename custom-manifest.json",
   ];
 
   static override flags = {
@@ -33,12 +33,16 @@ export class WorkspaceInitCommand extends Command {
       await initManifest(manifestPath, slug);
       this.log(`Created new workspace at ${manifestPath}`);
       this.log("\nNext steps:");
-      this.log("1. Add a connection:    rejot manifest connection add --slug my-db ...");
-      this.log("2. Add a data store:    rejot manifest datastore add --connection my-db ...");
       this.log(
-        "3. Add sub-manifests:   Edit the manifest and add relative paths to other manifest files in the 'workspaces' array",
+        `1. Add a connection:    ${this.config.bin} manifest connection add --slug my-db ...`,
       );
-      this.log("4. View workspace info: rejot workspace:info");
+      this.log(
+        `2. Add a data store:    ${this.config.bin} manifest datastore add --connection my-db ...`,
+      );
+      this.log(
+        `3. Add sub-manifests:   Edit the manifest and add relative paths to other manifest files in the 'workspaces' array`,
+      );
+      this.log(`4. View workspace info: ${this.config.bin} workspace info`);
     } catch (error) {
       if (error instanceof Error) {
         if ("code" in error && error.code === "EEXIST") {


### PR DESCRIPTION
And use spaces in all ID's, instead of :

Just a change to make all cli commands more similar. 