### PR TITLE
Oclif workarounds

### DIFF
--- a/apps/rejot-cli/bin/dev.js
+++ b/apps/rejot-cli/bin/dev.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env bun
 
-import { execute } from "@oclif/core";
+import { run } from "../src/index.ts";
 
-await execute({ development: true, dir: import.meta.url });
+await run();

--- a/apps/rejot-cli/bin/run.js
+++ b/apps/rejot-cli/bin/run.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
 
-import { execute } from "@oclif/core";
+import { run } from "../dist/src/index.js";
 
-await execute({ dir: import.meta.url });
+await run();

--- a/apps/rejot-cli/package.json
+++ b/apps/rejot-cli/package.json
@@ -13,7 +13,13 @@
     "test": "bun test **/*.test.ts",
     "check": "tsc --noEmit",
     "cli:schema": "bun run src/generate-schema.ts > cli-schema.json",
-    "build:bun": "sed -i 's|./dist/src/index.js|./src/index.ts|g' package.json"
+    "build:bun": "sed -i 's|./dist/src/index.js|./src/index.ts|g' bin/run.js",
+    "compile:linux": "bun build --target bun-linux-x64 --outfile rejot-cli --compile ./bin/run.js --production",
+    "compile:windows": "bun build --target bun-windows-x64 --outfile rejot-cli.exe --compile ./bin/run.js --production",
+    "compile:macos": "bun build --target bun-darwin-x64 --outfile rejot-cli --compile ./bin/run.js --production",
+    "compile:linux-arm": "bun build --target bun-linux-arm64 --outfile rejot-cli --compile ./bin/run.js --production",
+    "compile:macos-arm": "bun build --target bun-darwin-arm64 --outfile rejot-cli --compile ./bin/run.js --production",
+    "compile:all": "bun run compile:linux && bun run compile:windows && bun run compile:macos && bun run compile:linux-arm && bun run compile:macos-arm"
   },
   "bin": {
     "rejot-cli": "./bin/run.js"
@@ -39,12 +45,6 @@
   },
   "oclif": {
     "bin": "rejot-cli",
-    "commands": {
-      "strategy": "explicit",
-      "target": "./dist/src/index.js",
-      "identifier": "commands"
-    },
-    "dirname": "rejot-cli",
     "topicSeparator": " ",
     "description": "rejot-cli is a command line tool for managing ReJot Manifests and Sync Services.\nCheck out our quickstart guide at https://rejot.dev/docs/start/quickstart/"
   }

--- a/apps/rejot-cli/src/commands/collect-command.ts
+++ b/apps/rejot-cli/src/commands/collect-command.ts
@@ -24,6 +24,8 @@ const log = getLogger(import.meta.url);
 import { Args, Command, Flags } from "@oclif/core";
 
 export default class Collect extends Command {
+  static id = "collect";
+
   static override args = {
     schemas: Args.string({
       description: "The schema (TypeScript/Python) files to collect, separated by spaces.",

--- a/apps/rejot-cli/src/commands/manifest/manifest-info.command.ts
+++ b/apps/rejot-cli/src/commands/manifest/manifest-info.command.ts
@@ -7,7 +7,7 @@ import { ManifestPrinter } from "@rejot-dev/contract-tools/manifest/manifest-pri
 import { Command, Flags } from "@oclif/core";
 
 export class ManifestInfoCommand extends Command {
-  static override id = "manifest";
+  static override id = "manifest info";
   static override description = `Display and manage Rejot manifest file for configuring data synchronization.
   
   The manifest file defines:

--- a/apps/rejot-cli/src/index.ts
+++ b/apps/rejot-cli/src/index.ts
@@ -1,6 +1,10 @@
 import { ConsoleLogger } from "@rejot-dev/contract/logger";
 import { setLogger } from "@rejot-dev/contract/logger";
 
+import { Command, execute, Plugin } from "@oclif/core";
+import type { PJSON } from "@oclif/core/interfaces";
+
+import packagejson from "../package.json" with { type: "json" };
 import CollectCommand from "./commands/collect-command.ts";
 import { ManifestInfoCommand } from "./commands/manifest/manifest-info.command.ts";
 import { ManifestInitCommand } from "./commands/manifest/manifest-init.command.ts";
@@ -38,3 +42,59 @@ export const commands = {
 };
 
 setLogger(new ConsoleLogger("DEBUG"));
+
+// PJSON, is simply a type that oclif uses to load the package.json file.
+// We need to cast it to the PJSON type to avoid type errors, as our package.json contains the oclif field, bun just doesn't know about it.
+const pjson = packagejson as unknown as PJSON;
+
+class PreloadedRejotCli extends Plugin {
+  /**
+   * This plugin is used to preload the rejot-cli commands, so we do not have to rely on oclif's dynamic loading (which requires the package.json to be present in the root of the project).
+   * This also means we can now use bun compile to build the rejot-cli binary, and it will work out of the box.
+   */
+
+  constructor() {
+    super({
+      name: "rejot-cli",
+      root: import.meta.url,
+    });
+  }
+
+  pjson = pjson;
+  hooks = {};
+
+  commands: Command.Loadable[] = Object.values(commands).map((command) => {
+    return {
+      load: async () => {
+        return command;
+      },
+      aliases: [],
+      args: command.args,
+      flags: command.flags,
+      hidden: command.hidden,
+      hasDynamicHelp: command.hasDynamicHelp,
+      deprecateAliases: command.deprecateAliases,
+      id: command.id.replaceAll(" ", ":"),
+      hiddenAliases: command.hiddenAliases,
+      description: command.description,
+      examples: command.examples,
+    };
+  });
+}
+
+export async function run() {
+  const plugin = new PreloadedRejotCli();
+  await execute({
+    dir: import.meta.url,
+    loadOptions: {
+      isRoot: true,
+      pjson,
+      root: import.meta.url,
+      topics: plugin.topics,
+      pluginAdditions: {
+        core: [PreloadedRejotCli.name],
+      },
+      plugins: new Map([[PreloadedRejotCli.name, plugin]]),
+    },
+  });
+}

--- a/apps/rejot-cli/tsconfig.json
+++ b/apps/rejot-cli/tsconfig.json
@@ -7,6 +7,7 @@
   "include": [
     "**/*.ts",
     "**/*.tsx",
+    "package.json",
     "../../packages/contract/cli/cli-schema.test.ts",
     "../../packages/contract/cli/cli-schema.ts"
   ],


### PR DESCRIPTION
I was trying to move away from Oclif, but the parsing of arguments, and help functions are just so nice. Keeping just the parser is an option, 
The big plugin system is also nice to keep, so I looked at workarounds for the issues with dynamic command loading and found this.

It registers a new plugin, which provides all of our commands, instead of loading it from package.json. Oclif still expects a form of package.json, but that can be easily circumvented using `import packagejson from "../package.json" with { type: "json" };`


Let me know what you think, we can still scratch this, and still implement our own wrapper around `@oclif/core`
